### PR TITLE
Fix issues of parentpath/exists/getPathMap

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -121,6 +121,11 @@ public class CassandraPathDB
         String parentPath = getParentPath( path );
         String filename = getFilename( path );
 
+        if ( parentPath == null || filename == null )
+        {
+            logger.debug( "getPathMap::null, parentPath:{}, filename:{}", parentPath, filename );
+            return null;
+        }
         return pathMapMapper.get( fileSystem, parentPath, filename );
     }
 
@@ -138,6 +143,10 @@ public class CassandraPathDB
     @Override
     public boolean exists( String fileSystem, String path )
     {
+        if ( ROOT_DIR.equals( path ) )
+        {
+            return true;
+        }
         return getPathMap( fileSystem, path ) != null;
     }
 

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -133,7 +133,7 @@ public class CassandraPathDB
     public long getFileLastModified( String fileSystem, String path )
     {
         PathMap pathMap = getPathMap( fileSystem, path );
-        if ( pathMap != null )
+        if ( pathMap != null && pathMap.getFileId() != null )
         {
             return pathMap.getCreation().getTime();
         }

--- a/src/main/java/org/commonjava/storage/pathmapped/util/PathMapUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/PathMapUtils.java
@@ -15,6 +15,9 @@ public class PathMapUtils
     // looks weird but it splits "/path/to/my/file" -> [/][path/][to/][my/][file]
     private final static String EMPTY_CHAR_AFTER_SLASH = "(?<=/)";
 
+    /**
+     * Retrieve parent for the specified path. Prepend "/" if have not, and remove trailing "/" if have.
+     */
     public static String getParentPath( String path )
     {
         if ( ROOT_DIR.equals( path ) )
@@ -36,6 +39,10 @@ public class PathMapUtils
         if ( ret.length() <= 0 )
         {
             ret = ROOT_DIR;
+        }
+        if ( !ret.startsWith( "/" ) )
+        {
+            ret = "/" + ret;
         }
         return ret;
     }


### PR DESCRIPTION
This PR fixes a few integration issues. NPE from pathMapMapper.get(); exist for ROOT dir; and always prepend / for parent path field.