### PR TITLE
Unit test second round: Fix a path slashing problem for dir related

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -88,12 +88,32 @@ public class PathMappedFileManager
 
     public boolean exists( String fileSystem, String path )
     {
-        return pathDB.exists( fileSystem, path );
+
+        boolean generalCheck = pathDB.exists( fileSystem, path );
+        // path is file or dir with trailing "/" and exists
+        if ( generalCheck )
+        {
+            return true;
+        }
+
+        // path is dir with trailing "/" and  not exists
+        if ( path.endsWith( "/" ) )
+        {
+            return false;
+        }
+
+        // double check if path is dir and if exists
+        return pathDB.exists( fileSystem, path + "/" );
     }
 
     public boolean isDirectory( String fileSystem, String path )
     {
-        return pathDB.isDirectory( fileSystem, path );
+        if ( path == null )
+        {
+            return false;
+        }
+        final String pathWithSlash = path.endsWith( "/" ) ? path : path + "/";
+        return pathDB.isDirectory( fileSystem, pathWithSlash );
     }
 
     public boolean isFile( String fileSystem, String path )

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -99,10 +99,8 @@ public class CassandraPathDB
         ResultSet result =
                         session.execute( "SELECT * FROM " + keyspace + ".pathmap WHERE filesystem=? and parentpath=?;",
                                          fileSystem, path );
-        List<PathMap> list = new ArrayList<>();
         Result<DtxPathMap> ret = pathMapMapper.map( result );
-        ret.all().forEach( row -> list.add( row ) );
-        return list;
+        return new ArrayList<>( ret.all() );
     }
 
     @Override
@@ -287,7 +285,7 @@ public class CassandraPathDB
         // check parent paths
         String fromParentPath = getParentPath( fromPath );
         String toParentPath = getParentPath( toPath );
-        if ( !fromParentPath.equals( toParentPath ) )
+        if ( fromParentPath != null && !fromParentPath.equals( toParentPath ) )
         {
             makeDirs( toFileSystem, toParentPath );
         }
@@ -341,12 +339,8 @@ public class CassandraPathDB
         ResultSet result =
                         session.execute( "SELECT * FROM " + keyspace + ".reclaim WHERE partition = 0 AND deletion < ?;",
                                          threshold );
-        List<Reclaim> list = new ArrayList<>();
         Result<DtxReclaim> ret = reclaimMapper.map( result );
-        ret.all().forEach( row -> {
-            list.add( row );
-        } );
-        return list;
+        return new ArrayList<>( ret.all() );
     }
 
     @Override

--- a/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
+++ b/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
@@ -24,6 +24,7 @@ import org.commonjava.storage.pathmapped.config.DefaultPathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
 import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
 import org.commonjava.storage.pathmapped.datastax.CassandraPathDB;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -71,5 +72,10 @@ public abstract class AbstractCassandraFMTest {
 		File baseDir = temp.newFolder();
 		fileManager = new PathMappedFileManager( new DefaultPathMappedStorageConfig(), pathDB,
 												 new FileBasedPhysicalStore( baseDir ) );
+	}
+
+	@AfterClass
+	public static void shutDownCassandra() {
+		EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
 	}
 }

--- a/src/test/java/org/commonjava/storage/pathmapped/ConcurrentIOTest.java
+++ b/src/test/java/org/commonjava/storage/pathmapped/ConcurrentIOTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ConcurrentIOTest extends AbstractCassandraFMTest
+{
+    @Test
+    public void concurrentRead()
+            throws IOException, InterruptedException
+    {
+        File f = temp.newFile( "read-target.txt" );
+        String src = "This is a test";
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, f.getPath() ))
+        {
+            assertNotNull( os );
+            IOUtils.write( src.getBytes(), os );
+        }
+
+        final int runs = 10;
+        Executor executor = Executors.newFixedThreadPool( runs );
+        final CountDownLatch latch = new CountDownLatch( runs );
+        AtomicInteger failures = new AtomicInteger( 0 );
+        for ( int i = 0; i < runs; i++ )
+        {
+            executor.execute( () -> {
+                try (InputStream is = fileManager.openInputStream( TEST_FS, f.getPath() ))
+                {
+                    assertNotNull( is );
+                    String result = new String( IOUtils.toByteArray( is ), Charset.defaultCharset() );
+                    if ( !src.equals( result ) )
+                    {
+                        failures.addAndGet( 1 );
+                    }
+                }
+                catch ( IOException e )
+                {
+                    failures.addAndGet( 1 );
+                }
+                finally
+                {
+                    latch.countDown();
+                }
+            } );
+        }
+        latch.await();
+        assertThat( failures.get(), equalTo( 0 ) );
+    }
+
+    @Test
+    @Ignore
+    public void concurrentWrite()
+    {
+        //TODO: Cassandra based fm does not guarantee concurrent write on same file.
+        //      Each single concurrent output will write its new file entry and the last successful
+        //      one will be used in future in concurrent mode
+
+        //TODO: question: so does this mean there will be some dirty-read here? like write-read-write case?
+        fail( "concurrent write not support now!" );
+    }
+}


### PR DESCRIPTION
If a path without trailing slash comes, we don't if it is a dir or a file, so we should do double check by adding trailing slash.