### PR TITLE
Generate random fileid

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
@@ -13,8 +13,8 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static org.commonjava.storage.pathmapped.util.PathMapUtils.getFileId;
-import static org.commonjava.storage.pathmapped.util.PathMapUtils.getStoragePathByFileId;
+import static org.commonjava.storage.pathmapped.util.PathMapUtils.getRandomFileId;
+import static org.commonjava.storage.pathmapped.util.PathMapUtils.getStorageDir;
 
 public class FileBasedPhysicalStore implements PhysicalStore
 {
@@ -30,11 +30,11 @@ public class FileBasedPhysicalStore implements PhysicalStore
     @Override
     public FileInfo getFileInfo( String fileSystem, String path )
     {
-        String id = getFileId( fileSystem, path );
-
+        String dir = getStorageDir( fileSystem, path );
+        String id = getRandomFileId();
         FileInfo fileInfo = new FileInfo();
         fileInfo.setFileId( id );
-        fileInfo.setFileStorage( getStoragePathByFileId( id ) );
+        fileInfo.setFileStorage( Paths.get( dir, id ).toString() );
         return fileInfo;
     }
 

--- a/src/main/java/org/commonjava/storage/pathmapped/util/PathMapUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/PathMapUtils.java
@@ -6,6 +6,7 @@ import org.commonjava.storage.pathmapped.model.PathMap;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 
@@ -73,18 +74,24 @@ public class PathMapUtils
         return toks[toks.length - 1];
     }
 
-    public static String getFileId( String fileSystem, String path )
+    private static final int LEVEL_1_DIR_LENGTH = 2;
+
+    private static final int LEVEL_2_DIR_LENGTH = 2;
+
+    private static final int DIR_LENGTH = LEVEL_1_DIR_LENGTH + LEVEL_2_DIR_LENGTH;
+
+    public static String getRandomFileId()
     {
-        String uri = fileSystem + ":" + path;
-        return DigestUtils.md5Hex( uri );
+        return UUID.randomUUID().toString();
     }
 
-    public static String getStoragePathByFileId( String id )
+    public static String getStorageDir( String fileSystem, String path )
     {
-        String folder = id.substring( 0, 2 );
-        String subFolder = id.substring( 2, 4 );
-        String filename = id.substring( 4 );
-        return folder + "/" + subFolder + "/" + filename;
+        String uri = fileSystem + ":" + path;
+        String md5Hex = DigestUtils.md5Hex( uri );
+        String folder = md5Hex.substring( 0, LEVEL_1_DIR_LENGTH );
+        String subFolder = md5Hex.substring( LEVEL_1_DIR_LENGTH, DIR_LENGTH );
+        return folder + "/" + subFolder;
     }
 
     /**


### PR DESCRIPTION
I made a mistake with the fileid generation. That should be a random id, instead of generated from "system+path". 
This fix also generates the dir by the first 4 chars of the hash of "system+path" so that we get a clue where the file is located. That information is useful when indy ftests want to check the physical file existence. I.e., for something like repo-1:/foo/bar.jar, the physical file should be always in folder ab/cd, and the latest file under this folder should be (not theoretically but practically) what it want. 