### PR TITLE
Fix data type for file size

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
@@ -45,11 +45,8 @@ public class PathDBOutputStream
     {
         try
         {
-            synchronized ( this )
-            {
-                super.write( b );
-                size += 1;
-            }
+            super.write( b );
+            size += 1;
         }
         catch ( IOException e )
         {

--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
@@ -25,7 +25,7 @@ public class PathDBOutputStream
 
     private final String fileStorage;
 
-    private int size;
+    private long size;
 
     public PathDBOutputStream( PathDB pathDB, PhysicalStore physicalStore, String fileSystem, String path,
                                FileInfo fileInfo, OutputStream out )
@@ -45,8 +45,11 @@ public class PathDBOutputStream
     {
         try
         {
-            super.write( b );
-            size += 1;
+            synchronized ( this )
+            {
+                super.write( b );
+                size += 1;
+            }
         }
         catch ( IOException e )
         {

--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -84,7 +84,7 @@ public class PathMappedFileManager
         } ).toArray( String[]::new );
     }
 
-    public int getFileLength( String fileSystem, String path )
+    public long getFileLength( String fileSystem, String path )
     {
         if ( path == null )
         {

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -104,7 +104,7 @@ public class CassandraPathDB
     }
 
     @Override
-    public int getFileLength( String fileSystem, String path )
+    public long getFileLength( String fileSystem, String path )
     {
         PathMap pathMap = getPathMap( fileSystem, path );
         if ( pathMap != null )
@@ -159,7 +159,7 @@ public class CassandraPathDB
     }
 
     @Override
-    public void insert( String fileSystem, String path, Date date, String fileId, int size, String fileStorage )
+    public void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage )
     {
         DtxPathMap pathMap = new DtxPathMap();
         pathMap.setFileSystem( fileSystem );

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
@@ -28,7 +28,7 @@ public class DtxPathMap implements PathMap
     private Date creation;
 
     @Column
-    private int size;
+    private long size;
 
     @Column
     private String fileStorage;
@@ -37,7 +37,7 @@ public class DtxPathMap implements PathMap
     {
     }
 
-    public DtxPathMap( String fileSystem, String parentPath, String filename, String fileId, Date creation, int size, String fileStorage )
+    public DtxPathMap( String fileSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage )
     {
         this.fileSystem = fileSystem;
         this.parentPath = parentPath;
@@ -58,12 +58,12 @@ public class DtxPathMap implements PathMap
         this.fileId = fileId;
     }
 
-    public int getSize()
+    public long getSize()
     {
         return size;
     }
 
-    public void setSize( int size )
+    public void setSize( long size )
     {
         this.size = size;
     }

--- a/src/main/java/org/commonjava/storage/pathmapped/jpa/JPAPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/jpa/JPAPathDB.java
@@ -54,7 +54,7 @@ public class JPAPathDB
     }
 
     @Override
-    public int getFileLength( String fileSystem, String path )
+    public long getFileLength( String fileSystem, String path )
     {
         PathMap pathMap = findPathMap( fileSystem, path );
         if ( pathMap != null )
@@ -92,7 +92,7 @@ public class JPAPathDB
     }
 
     @Override
-    public void insert( String fileSystem, String path, Date date, String fileId, int size, String fileStorage )
+    public void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage )
     {
         JpaPathMap pathMap = new JpaPathMap();
         JpaPathKey pathKey = getPathKey( fileSystem, path );

--- a/src/main/java/org/commonjava/storage/pathmapped/jpa/model/JpaPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/jpa/model/JpaPathMap.java
@@ -23,7 +23,7 @@ public class JpaPathMap implements PathMap
     private Date creation;
 
     @Column
-    private int size;
+    private long size;
 
     @Column( name = "filestorage" )
     private String fileStorage;
@@ -32,7 +32,7 @@ public class JpaPathMap implements PathMap
     {
     }
 
-    public JpaPathMap( JpaPathKey pathKey, String fileId, Date creation, int size, String fileStorage )
+    public JpaPathMap( JpaPathKey pathKey, String fileId, Date creation, long size, String fileStorage )
     {
         this.pathKey = pathKey;
         this.fileId = fileId;
@@ -79,12 +79,12 @@ public class JpaPathMap implements PathMap
         this.fileId = fileId;
     }
 
-    public int getSize()
+    public long getSize()
     {
         return size;
     }
 
-    public void setSize( int size )
+    public void setSize( long size )
     {
         this.size = size;
     }

--- a/src/main/java/org/commonjava/storage/pathmapped/model/PathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/model/PathMap.java
@@ -12,7 +12,7 @@ public interface PathMap
 
     String getFileId();
 
-    int getSize();
+    long getSize();
 
     String getFileStorage();
 

--- a/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -10,13 +10,13 @@ public interface PathDB
 {
     List<PathMap> list( String fileSystem, String path );
 
-    int getFileLength( String fileSystem, String path );
+    long getFileLength( String fileSystem, String path );
 
     long getFileLastModified( String fileSystem, String path );
 
     boolean exists( String fileSystem, String path );
 
-    void insert( String fileSystem, String path, Date date, String fileId, int size, String fileStorage );
+    void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage );
 
     void insert( PathMap pathMap );
 

--- a/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
@@ -22,7 +22,7 @@ public class CassandraPathDBUtils
                         + "filename varchar,"
                         + "fileid varchar,"
                         + "creation timestamp,"
-                        + "size int,"
+                        + "size bigint,"
                         + "filestorage varchar,"
                         + "PRIMARY KEY (filesystem, parentpath, filename)"
                         + ");";

--- a/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
+++ b/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
@@ -104,10 +104,10 @@ public class SimpleIOTest
     public void getFileMetadata()
             throws Exception
     {
-        assertThat( fileManager.getFileLength( TEST_FS, null ), equalTo( 0 ) );
+        assertThat( fileManager.getFileLength( TEST_FS, null ), equalTo( 0L ) );
         assertThat( fileManager.getFileLastModified( TEST_FS, null ), equalTo( -1L ) );
         readWrittenFile();
-        assertThat( fileManager.getFileLength( TEST_FS, path1 ), equalTo( simpleContent.length() ) );
+        assertThat( fileManager.getFileLength( TEST_FS, path1 ), equalTo( (long)simpleContent.length() ) );
         assertThat( fileManager.getFileLastModified( TEST_FS, path1 ) > 0, equalTo( true ) );
     }
 


### PR DESCRIPTION
We should use long for file size to avoid overflow for some big files. See java.io.File.length()