### PR TITLE
Fix some issues found during Indy ftests

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
@@ -54,7 +54,7 @@ public class FileBasedPhysicalStore implements PhysicalStore
     public InputStream getInputStream( String storageFile ) throws IOException
     {
         File f = new File( baseDir, storageFile );
-        if ( !f.exists() )
+        if ( f.isDirectory() || !f.exists() )
         {
             logger.debug( "Target file not exists, file: {}", f.getAbsolutePath() );
             return null;

--- a/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
@@ -53,7 +53,13 @@ public class FileBasedPhysicalStore implements PhysicalStore
     @Override
     public InputStream getInputStream( String storageFile ) throws IOException
     {
-        return new FileInputStream( new File( baseDir, storageFile ) );
+        File f = new File( baseDir, storageFile );
+        if ( !f.exists() )
+        {
+            logger.debug( "Target file not exists, file: {}", f.getAbsolutePath() );
+            return null;
+        }
+        return new FileInputStream( f );
     }
 
     @Override

--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -8,6 +8,7 @@ import org.commonjava.storage.pathmapped.spi.PhysicalStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -15,7 +16,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class PathMappedFileManager
+import static org.commonjava.storage.pathmapped.util.PathMapUtils.ROOT_DIR;
+
+public class PathMappedFileManager implements Closeable
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -117,6 +120,10 @@ public class PathMappedFileManager
         {
             return false;
         }
+        if ( ROOT_DIR.equals( path ) )
+        {
+            return true;
+        }
         final String pathWithSlash = path.endsWith( "/" ) ? path : path + "/";
         return pathDB.isDirectory( fileSystem, pathWithSlash );
     }
@@ -165,4 +172,12 @@ public class PathMappedFileManager
         return gcResults;
     }
 
+    @Override
+    public void close() throws IOException
+    {
+        if ( pathDB instanceof Closeable )
+        {
+            ( (Closeable) pathDB ).close();
+        }
+    }
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -253,14 +253,14 @@ public class CassandraPathDB
     private ReverseMap deleteFromReverseMap( String fileId, String path )
     {
         logger.debug( "Delete from reverseMap, fileId: {}, path: {}", fileId, path );
-        session.execute( "UPDATE " + keyspace + ".reversemap SET paths -= {'" + path + "'} WHERE fileid=?;", fileId );
+        session.execute( "UPDATE " + keyspace + ".reversemap SET paths = paths - {'" + path + "'} WHERE fileid=?;", fileId );
         return reverseMapMapper.get( fileId );
     }
 
     private void addToReverseMap( String fileId, String path )
     {
         logger.debug( "Add to reverseMap, fileId: {}, path: {}", fileId, path );
-        session.execute( "UPDATE " + keyspace + ".reversemap SET paths += {'" + path + "'} WHERE fileid=?;", fileId );
+        session.execute( "UPDATE " + keyspace + ".reversemap SET paths = paths + {'" + path + "'} WHERE fileid=?;", fileId );
     }
 
     private void reclaim( String fileId, String fileStorage )


### PR DESCRIPTION
This include three fixes:
1. Fix isDir for ROOT; It should return true.
2. Implements Closeable for PathMappedFileManager; This is used for caller to close connections. 
3. Fix syntax error under lower level cql version; The += and -= in CQL is only works for some high versions. For safety, replace them by normal + and -.