### PR TITLE
Improve DB access performance via prepared statement and add shortcuts

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -124,8 +124,7 @@ public class PathMappedFileManager implements Closeable
         {
             return true;
         }
-        final String pathWithSlash = path.endsWith( "/" ) ? path : path + "/";
-        return pathDB.isDirectory( fileSystem, pathWithSlash );
+        return pathDB.isDirectory( fileSystem, path );
     }
 
     public boolean isFile( String fileSystem, String path )

--- a/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
+++ b/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
@@ -426,7 +426,7 @@ public class SimpleIOTest
     private void assertPathWithChecker( PathChecker<Boolean> checker, String fileSystem, String path, boolean expected )
     {
         assertThat( checker.checkPath( fileSystem, path ), equalTo( expected ) );
-        assertThat( checker.checkPath( fileSystem, path + "/" ), equalTo( expected ) );
+//        assertThat( checker.checkPath( fileSystem, path + "/" ), equalTo( expected ) );
     }
 
     @Override


### PR DESCRIPTION
1. Use prepared statements.
2. Use shortcut for isDir/isFile. Briefly, if the caller passes in a path with a "/", isDir will immediately return true. This serves the case of listing recursively a repository without checking again for the sub-folders (reduce many db accesses).