### PR TITLE
Add file checksum to de-dup file stores

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -11,11 +11,15 @@ public class DefaultPathMappedStorageConfig
 
     private final int DEFAULT_GC_GRACE_PERIOD_IN_HOURS = 24;
 
+    private final String DEFAULT_FILE_CHECKSUM_ALGORITHM = "MD5";
+
     private int gcGracePeriodInHours = DEFAULT_GC_GRACE_PERIOD_IN_HOURS;
 
     private int gcIntervalInMinutes = DEFAULT_GC_INTERVAL_IN_MINUTES;
 
     private int gcBatchSize = DEFAULT_GC_BATCH_SIZE;
+
+    private String fileChecksumAlgorithm = DEFAULT_FILE_CHECKSUM_ALGORITHM;
 
     public DefaultPathMappedStorageConfig()
     {
@@ -52,6 +56,17 @@ public class DefaultPathMappedStorageConfig
     public boolean isSubsystemEnabled( String fileSystem )
     {
         return false;
+    }
+
+    @Override
+    public String getFileChecksumAlgorithm()
+    {
+        return fileChecksumAlgorithm;
+    }
+
+    public void setFileChecksumAlgorithm( String fileChecksumAlgorithm )
+    {
+        this.fileChecksumAlgorithm = fileChecksumAlgorithm;
     }
 
     private Map<String, Object> properties;

--- a/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -7,6 +7,8 @@ public interface PathMappedStorageConfig
 
     int getGCGracePeriodInHours();
 
+    String getFileChecksumAlgorithm();
+
     boolean isSubsystemEnabled( String fileSystem );
 
     Object getProperty( String key );

--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -12,6 +12,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +62,16 @@ public class PathMappedFileManager implements Closeable
     public OutputStream openOutputStream( String fileSystem, String path ) throws IOException
     {
         FileInfo fileInfo = physicalStore.getFileInfo( fileSystem, path );
-        return new PathDBOutputStream( pathDB, physicalStore, fileSystem, path, fileInfo,
-                                       physicalStore.getOutputStream( fileInfo ) );
+        try
+        {
+            return new PathDBOutputStream( pathDB, physicalStore, fileSystem, path, fileInfo,
+                                           physicalStore.getOutputStream( fileInfo ),
+                                           config.getFileChecksumAlgorithm() );
+        }
+        catch ( NoSuchAlgorithmException e )
+        {
+            throw new IOException( "Error: checksum checking not correct", e );
+        }
     }
 
     public boolean delete( String fileSystem, String path )

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxFileChecksum.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxFileChecksum.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.datastax.model;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.commonjava.storage.pathmapped.model.FileChecksum;
+
+import java.util.Objects;
+
+@Table( name = "filechecksum", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxFileChecksum
+        implements FileChecksum
+{
+    @PartitionKey
+    private String checksum;
+
+    @Column
+    private String fileId;
+
+    @Column
+    private String storage;
+
+    public DtxFileChecksum()
+    {
+    }
+
+    public DtxFileChecksum( String checksum, String fileId, String storage )
+    {
+        this.checksum = checksum;
+        this.fileId = fileId;
+        this.storage = storage;
+    }
+
+    public String getFileId()
+    {
+        return fileId;
+    }
+
+    public void setFileId( String fileId )
+    {
+        this.fileId = fileId;
+    }
+
+    public String getChecksum()
+    {
+        return checksum;
+    }
+
+    public void setChecksum( String checksum )
+    {
+        this.checksum = checksum;
+    }
+
+    @Override
+    public String getStorage()
+    {
+        return storage;
+    }
+
+    public void setStorage( String storage )
+    {
+        this.storage = storage;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        DtxFileChecksum that = (DtxFileChecksum) o;
+        return fileId.equals( that.fileId );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( checksum );
+    }
+}

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
@@ -33,11 +33,14 @@ public class DtxPathMap implements PathMap
     @Column
     private String fileStorage;
 
+    @Column
+    private String checksum;
+
     public DtxPathMap()
     {
     }
 
-    public DtxPathMap( String fileSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage )
+    public DtxPathMap( String fileSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage, String checksum )
     {
         this.fileSystem = fileSystem;
         this.parentPath = parentPath;
@@ -46,6 +49,7 @@ public class DtxPathMap implements PathMap
         this.creation = creation;
         this.size = size;
         this.fileStorage = fileStorage;
+        this.checksum = checksum;
     }
 
     public String getFileId()
@@ -116,6 +120,17 @@ public class DtxPathMap implements PathMap
     public void setFilename( String filename )
     {
         this.filename = filename;
+    }
+
+    @Override
+    public String getChecksum()
+    {
+        return checksum;
+    }
+
+    public void setChecksum( String checksum )
+    {
+        this.checksum = checksum;
     }
 
     @Override

--- a/src/main/java/org/commonjava/storage/pathmapped/jpa/JPAPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/jpa/JPAPathDB.java
@@ -25,6 +25,9 @@ import java.util.List;
 public class JPAPathDB
                 implements PathDB
 {
+    //TODO: checksum dedupe is not implemented yet in JPAPathDB, will implement it later. Can refer the way of
+    //      CassandraPathDB to do this.
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private final EntityManagerFactory factory;
@@ -92,7 +95,7 @@ public class JPAPathDB
     }
 
     @Override
-    public void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage )
+    public void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage, String checksum )
     {
         JpaPathMap pathMap = new JpaPathMap();
         JpaPathKey pathKey = getPathKey( fileSystem, path );
@@ -101,11 +104,11 @@ public class JPAPathDB
         pathMap.setFileId( fileId );
         pathMap.setFileStorage( fileStorage );
         pathMap.setSize( size );
-        insert( pathMap );
+        insert( pathMap, checksum );
     }
 
     @Override
-    public void insert( PathMap pathMap )
+    public void insert( PathMap pathMap, String checksum )
     {
         logger.debug( "Insert: {}", pathMap );
 
@@ -261,9 +264,10 @@ public class JPAPathDB
             makeDirs( toFileSystem, toParentPath );
         }
 
+        //TODO: need to implement checksum de-dupe in future, and add checksum here
         transactionAnd( () -> {
             entitymanager.persist( new JpaPathMap( to, pathMap.getFileId(), pathMap.getCreation(), pathMap.getSize(),
-                                                   pathMap.getFileStorage() ) );
+                                                   pathMap.getFileStorage(), "" ) );
         } );
         return true;
     }

--- a/src/main/java/org/commonjava/storage/pathmapped/jpa/model/JpaFileChecksum.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/jpa/model/JpaFileChecksum.java
@@ -10,7 +10,8 @@ import java.util.Objects;
 
 @Entity
 @Table( name = "filechecksum" )
-public class JpaFileChecksum implements FileChecksum
+public class JpaFileChecksum
+        implements FileChecksum
 {
     @Id
     private String checksum;
@@ -18,14 +19,18 @@ public class JpaFileChecksum implements FileChecksum
     @Column( name = "fileid" )
     private String fileId;
 
+    @Column( name = "storage" )
+    private String storage;
+
     public JpaFileChecksum()
     {
     }
 
-    public JpaFileChecksum( String checksum, String fileId )
+    public JpaFileChecksum( String checksum, String fileId, String storage )
     {
         this.checksum = checksum;
         this.fileId = fileId;
+        this.storage = storage;
     }
 
     public String getFileId()
@@ -49,12 +54,27 @@ public class JpaFileChecksum implements FileChecksum
     }
 
     @Override
+    public String getStorage()
+    {
+        return storage;
+    }
+
+    public void setStorage( String storage )
+    {
+        this.storage = storage;
+    }
+
+    @Override
     public boolean equals( Object o )
     {
         if ( this == o )
+        {
             return true;
+        }
         if ( o == null || getClass() != o.getClass() )
+        {
             return false;
+        }
         JpaFileChecksum that = (JpaFileChecksum) o;
         return checksum.equals( that.checksum );
     }

--- a/src/main/java/org/commonjava/storage/pathmapped/jpa/model/JpaPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/jpa/model/JpaPathMap.java
@@ -28,17 +28,21 @@ public class JpaPathMap implements PathMap
     @Column( name = "filestorage" )
     private String fileStorage;
 
+    @Column( name = "checksum" )
+    private String checksum;
+
     public JpaPathMap()
     {
     }
 
-    public JpaPathMap( JpaPathKey pathKey, String fileId, Date creation, long size, String fileStorage )
+    public JpaPathMap( JpaPathKey pathKey, String fileId, Date creation, long size, String fileStorage, String checksum )
     {
         this.pathKey = pathKey;
         this.fileId = fileId;
         this.creation = creation;
         this.size = size;
         this.fileStorage = fileStorage;
+        this.checksum = checksum;
     }
 
     public JpaPathKey getPathKey()
@@ -107,6 +111,17 @@ public class JpaPathMap implements PathMap
     public void setCreation( Date creation )
     {
         this.creation = creation;
+    }
+
+    @Override
+    public String getChecksum()
+    {
+        return checksum;
+    }
+
+    public void setChecksum( String checksum )
+    {
+        this.checksum = checksum;
     }
 
     @Override

--- a/src/main/java/org/commonjava/storage/pathmapped/model/FileChecksum.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/model/FileChecksum.java
@@ -5,4 +5,6 @@ public interface FileChecksum
     String getFileId();
 
     String getChecksum();
+
+    String getStorage();
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/model/PathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/model/PathMap.java
@@ -17,4 +17,6 @@ public interface PathMap
     String getFileStorage();
 
     Date getCreation();
+
+    String getChecksum();
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -16,9 +16,9 @@ public interface PathDB
 
     boolean exists( String fileSystem, String path );
 
-    void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage );
+    void insert( String fileSystem, String path, Date date, String fileId, long size, String fileStorage, String checksum );
 
-    void insert( PathMap pathMap );
+    void insert( PathMap pathMap, String checksum );
 
     boolean isDirectory( String fileSystem, String path );
 

--- a/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
@@ -24,6 +24,7 @@ public class CassandraPathDBUtils
                         + "creation timestamp,"
                         + "size bigint,"
                         + "filestorage varchar,"
+                        + "checksum varchar,"
                         + "PRIMARY KEY (filesystem, parentpath, filename)"
                         + ");";
     }
@@ -48,4 +49,13 @@ public class CassandraPathDBUtils
                         + ");";
     }
 
+    public static String getSchemaCreateTableFileChecksum( String keyspace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".filechecksum ("
+                        + "checksum varchar,"
+                        + "fileid varchar,"
+                        + "storage varchar,"
+                        + "PRIMARY KEY (checksum)"
+                        + ");";
+    }
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/util/ChecksumCalculator.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/ChecksumCalculator.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
+
+public class ChecksumCalculator
+{
+    private final MessageDigest digester;
+
+    private String digestHex;
+
+    public ChecksumCalculator( final String algorithm )
+            throws NoSuchAlgorithmException
+    {
+        this.digester = MessageDigest.getInstance( algorithm );
+    }
+
+    public final void update( final byte[] data )
+    {
+        digester.update( data );
+    }
+
+    public final void update( final byte data )
+    {
+        digester.update( data );
+    }
+
+    public synchronized String getDigestHex()
+    {
+        if ( digestHex == null )
+        {
+            digestHex = encodeHexString( digester.digest() );
+        }
+        return digestHex;
+    }
+}

--- a/src/test/java/org/commonjava/storage/pathmapped/ChecksumDedupeTest.java
+++ b/src/test/java/org/commonjava/storage/pathmapped/ChecksumDedupeTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ChecksumDedupeTest
+        extends AbstractCassandraFMTest
+{
+    @Test
+    public void checksumDupe()
+            throws Exception
+    {
+        writeWithContent( TEST_FS, path1, simpleContent );
+        writeWithContent( TEST_FS, path2, simpleContent );
+
+        String pathStorage1 = fileManager.getFileStoragePath( TEST_FS, path1 );
+        String pathStorage2 = fileManager.getFileStoragePath( TEST_FS, path2 );
+
+        assertThat( pathStorage1, equalTo( pathStorage2 ) );
+
+        checkPhysicalFile( 2, 1, pathStorage1 );
+
+        checkRead( TEST_FS, path1, true, simpleContent );
+        checkRead( TEST_FS, path2, true, simpleContent );
+
+    }
+
+    @Test
+    public void checksumNotDupe()
+            throws Exception
+    {
+        writeWithContent( TEST_FS, path1, simpleContent );
+        final String newContent = simpleContent + "new";
+        writeWithContent( TEST_FS, path2, newContent );
+
+        final String pathStorage1 = fileManager.getFileStoragePath( TEST_FS, path1 );
+        final String pathStorage2 = fileManager.getFileStoragePath( TEST_FS, path2 );
+
+        assertThat( pathStorage1, not( pathStorage2 ) );
+
+        checkPhysicalFile( 2, 2, pathStorage1, pathStorage2 );
+
+        checkRead( TEST_FS, path1, true, simpleContent );
+        checkRead( TEST_FS, path2, true, newContent );
+    }
+
+    @Test
+    public void checksumDelete()
+            throws Exception
+    {
+        writeWithContent( TEST_FS, path1, simpleContent );
+        writeWithContent( TEST_FS, path2, simpleContent );
+        final String path3 = pathParent+"/sub3/target3.txt";
+        writeWithContent( TEST_FS, path3, simpleContent );
+
+        final String pathStorage1 = fileManager.getFileStoragePath( TEST_FS, path1 );
+        final String pathStorage2 = fileManager.getFileStoragePath( TEST_FS, path2 );
+        final String pathStorage3 = fileManager.getFileStoragePath( TEST_FS, path3 );
+
+        fileManager.delete( TEST_FS, path3 );
+        checkPhysicalFile( 3, 1, pathStorage1 );
+        checkRead( TEST_FS, path1, true, simpleContent );
+        checkRead( TEST_FS, path2, true, simpleContent );
+        checkRead( TEST_FS, path3, false, null );
+
+        fileManager.delete( TEST_FS, path2 );
+        checkPhysicalFile( 1, 1, pathStorage1 );
+        checkRead( TEST_FS, path1, true, simpleContent );
+        checkRead( TEST_FS, path2, false, null );
+        checkRead( TEST_FS, path3, false, null );
+
+        fileManager.delete( TEST_FS, path1 );
+        checkPhysicalFile( 1, 0 );
+        checkRead( TEST_FS, path1, false, null );
+        checkRead( TEST_FS, path2, false, null );
+        checkRead( TEST_FS, path3, false, null );
+
+        writeWithContent( TEST_FS, path1, simpleContent );
+        final String newPathStorage1 = fileManager.getFileStoragePath( TEST_FS, path1 );
+        assertThat(newPathStorage1, not(pathStorage1));
+        checkPhysicalFile( 1, 1, newPathStorage1 );
+        checkRead( TEST_FS, path1, true, simpleContent );
+        checkRead( TEST_FS, path2, false, null );
+        checkRead( TEST_FS, path3, false, null );
+
+    }
+
+    private void checkPhysicalFile( final int filesBeforeGC, final int filesAfterGC, final String... pathsShouldCheck )
+            throws Exception
+    {
+        checkFileCount( filesBeforeGC );
+
+        triggerGC();
+
+        Set<String> paths = checkFileCount( filesAfterGC );
+
+        for ( String pc : pathsShouldCheck )
+        {
+            boolean matched = false;
+            for ( String p : paths )
+            {
+                matched = p.contains( pc );
+                if ( matched )
+                {
+                    break;
+                }
+            }
+            if ( !matched )
+            {
+                fail( String.format( "Failed: not matched for %s in all paths %s", pc, paths ) );
+            }
+        }
+    }
+
+    private Set<String> checkFileCount( final int fileCount )
+            throws IOException
+    {
+        Set<String> paths = new HashSet<>( fileCount );
+        Files.walk( Paths.get( getBaseDir() ) )
+             .filter( p -> Files.isRegularFile( p ) )
+             .map( Path::toString )
+             .forEach( paths::add );
+        assertThat( paths.size(), equalTo( fileCount ) );
+        return paths;
+    }
+
+    private void triggerGC()
+            throws InterruptedException
+    {
+        fileManager.gc();
+        Thread.sleep( GC_WAIT_MS );
+    }
+
+    private void checkRead( final String fileSys, final String path, final boolean exists,
+                            final String expected )
+            throws IOException
+    {
+        try (InputStream is = fileManager.openInputStream( fileSys, path ))
+        {
+            if ( exists )
+            {
+                assertThat( is, notNullValue() );
+                assertThat( IOUtils.toString( is ), equalTo( expected ) );
+            }
+            else
+            {
+                assertThat( is, nullValue() );
+            }
+        }
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -8,10 +8,9 @@
     </encoder>
   </appender>
 
-  <logger name="org.commonjava.util.partyline" level="TRACE" />
-  <logger name="org.commonjava.util.cdi.weft" level="TRACE" />
+  <logger name="org.commonjava.storage.pathmapped" level="TRACE" />
 
-  <root level="TRACE">
+  <root level="ERROR">
     <appender-ref ref="STDOUT" />
   </root>
 


### PR DESCRIPTION
  * Add new filechecksum table, stores (checksum, fileid, storage)
  * When write new file, will check checksum against checksum table for
duplication verification
  * If checksum dupe, will use existed fileid and storage for new file
as file path.
  * When deletion, only when all fileids are not referenced, then the checksum
and storage can be removed.