### PR TITLE
Simplify getStorageDir so not confuse us

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
@@ -30,8 +30,8 @@ public class FileBasedPhysicalStore implements PhysicalStore
     @Override
     public FileInfo getFileInfo( String fileSystem, String path )
     {
-        String dir = getStorageDir( fileSystem, path );
         String id = getRandomFileId();
+        String dir = getStorageDir( id );
         FileInfo fileInfo = new FileInfo();
         fileInfo.setFileId( id );
         fileInfo.setFileStorage( Paths.get( dir, id ).toString() );

--- a/src/main/java/org/commonjava/storage/pathmapped/util/PathMapUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/PathMapUtils.java
@@ -1,6 +1,5 @@
 package org.commonjava.storage.pathmapped.util;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.commonjava.storage.pathmapped.model.PathMap;
 
 import java.util.Collections;
@@ -85,12 +84,10 @@ public class PathMapUtils
         return UUID.randomUUID().toString();
     }
 
-    public static String getStorageDir( String fileSystem, String path )
+    public static String getStorageDir( String fileId )
     {
-        String uri = fileSystem + ":" + path;
-        String md5Hex = DigestUtils.md5Hex( uri );
-        String folder = md5Hex.substring( 0, LEVEL_1_DIR_LENGTH );
-        String subFolder = md5Hex.substring( LEVEL_1_DIR_LENGTH, DIR_LENGTH );
+        String folder = fileId.substring( 0, LEVEL_1_DIR_LENGTH );
+        String subFolder = fileId.substring( LEVEL_1_DIR_LENGTH, DIR_LENGTH );
         return folder + "/" + subFolder;
     }
 


### PR DESCRIPTION
Simplify getStorageDir to exclude anything but fileId. 
I used hashed filesystem:path for Indy ftests to "guess" the physical file but now I've got a better idea for that. We don't need this.