### PR TITLE
Add save protection for checksum table update

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static com.datastax.driver.mapping.Mapper.Option.ifNotExists;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.*;
 import static org.commonjava.storage.pathmapped.util.PathMapUtils.ROOT_DIR;
@@ -246,7 +247,8 @@ public class CassandraPathDB
         else
         {
             logger.debug( "File checksum not exists, marked current file {} as primary", pathMap );
-            fileChecksumMapper.save( new DtxFileChecksum( checksum, pathMap.getFileId(), pathMap.getFileStorage() ) );
+            fileChecksumMapper.save( new DtxFileChecksum( checksum, pathMap.getFileId(), pathMap.getFileStorage() ),
+                                     ifNotExists( true ) );
         }
 
         pathMapMapper.save( (DtxPathMap) pathMap );


### PR DESCRIPTION
The ifNotExists option will let cassandra do some type of "Compare and Set" update according to the save key in table when concurrent update happen, which will not update some exists records with the same key. 
So for this issue, I'm thinking if we need some type of transaction or similar support from cassandra(or lock) during the insert operation, because the insert operation will involve several steps and tables to update(pathmap, filechecksum, reversemap). 