### PR TITLE
Add a clearAll to PathMappedFileManager so caller can clean DB in test

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -215,4 +215,9 @@ public class PathMappedFileManager implements Closeable
             ( (Closeable) pathDB ).close();
         }
     }
+
+    public void clearAll()
+    {
+        pathDB.clearAll();
+    }
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -488,4 +488,10 @@ public class CassandraPathDB
         return ret - Duration.ofHours( gcGracePeriodInHours ).toMillis();
     }
 
+    @Override
+    public void clearAll()
+    {
+        session.execute( "DROP KEYSPACE IF EXISTS " + keyspace );
+    }
+
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -37,4 +37,6 @@ public interface PathDB
     default List<Reclaim> listOrphanedFiles() { return listOrphanedFiles( 0 ); }
 
     void removeFromReclaim( Reclaim reclaim );
+
+    default void clearAll() {}
 }


### PR DESCRIPTION
This is mainly for Indy ftests. 