### PR TITLE
Support cassandra pathdb subsystem

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -53,12 +53,6 @@ public class DefaultPathMappedStorageConfig
     }
 
     @Override
-    public boolean isSubsystemEnabled( String fileSystem )
-    {
-        return false;
-    }
-
-    @Override
     public String getFileChecksumAlgorithm()
     {
         return fileChecksumAlgorithm;

--- a/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -9,7 +9,7 @@ public interface PathMappedStorageConfig
 
     String getFileChecksumAlgorithm();
 
-    boolean isSubsystemEnabled( String fileSystem );
+    default boolean isSubsystemEnabled() { return true; }
 
     Object getProperty( String key );
 

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/CassandraPathDB.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.*;
 import static org.commonjava.storage.pathmapped.util.PathMapUtils.ROOT_DIR;
@@ -106,14 +107,14 @@ public class CassandraPathDB
         reclaimMapper = manager.mapper( DtxReclaim.class, keyspace );
         fileChecksumMapper = manager.mapper( DtxFileChecksum.class, keyspace );
 
-        preparedSingleExistQuery = session.prepare(
-                        "SELECT count(*) FROM " + keyspace + ".pathmap WHERE filesystem=? and parentpath=? and filename=?;" );
+        preparedSingleExistQuery = session.prepare( "SELECT count(*) FROM " + keyspace
+                                                                    + ".pathmap WHERE filesystem=? and subsystem=? and parentpath=? and filename=?;" );
 
         preparedDoubleExistQuery = session.prepare( "SELECT count(*) FROM " + keyspace
-                                                                    + ".pathmap WHERE filesystem=? and parentpath=? and filename in (?,?);" );
+                                                                    + ".pathmap WHERE filesystem=? and subsystem=? and parentpath=? and filename in (?,?);" );
 
-        preparedListQuery =
-                        session.prepare( "SELECT * FROM " + keyspace + ".pathmap WHERE filesystem=? and parentpath=?;" );
+        preparedListQuery = session.prepare(
+                        "SELECT * FROM " + keyspace + ".pathmap WHERE filesystem=? and subsystem=? and parentpath=?;" );
     }
 
     @Override
@@ -134,7 +135,7 @@ public class CassandraPathDB
     public List<PathMap> list( String fileSystem, String path )
     {
         String parentPath = normalizeParentPath( path );
-        BoundStatement bound = preparedListQuery.bind( fileSystem, parentPath );
+        BoundStatement bound = preparedListQuery.bind( fileSystem, calculateSubsystem( parentPath ), parentPath );
         ResultSet result = session.execute( bound );
         Result<DtxPathMap> ret = pathMapMapper.map( result );
         return new ArrayList<>( ret.all() );
@@ -161,7 +162,7 @@ public class CassandraPathDB
             logger.debug( "getPathMap::null, parentPath:{}, filename:{}", parentPath, filename );
             return null;
         }
-        return pathMapMapper.get( fileSystem, parentPath, filename );
+        return pathMapMapper.get( fileSystem, calculateSubsystem( parentPath ), parentPath, filename );
     }
 
     @Override
@@ -192,11 +193,11 @@ public class CassandraPathDB
         BoundStatement bound;
         if ( filename.endsWith( "/" ) )
         {
-            bound = preparedSingleExistQuery.bind( fileSystem, parentPath, filename );
+            bound = preparedSingleExistQuery.bind( fileSystem, calculateSubsystem( parentPath ), parentPath, filename );
         }
         else
         {
-            bound = preparedDoubleExistQuery.bind( fileSystem, parentPath, filename, filename + "/" );
+            bound = preparedDoubleExistQuery.bind( fileSystem, calculateSubsystem( parentPath ), parentPath, filename, filename + "/" );
         }
         ResultSet result = session.execute( bound );
         long count = result.one().get( 0, Long.class );
@@ -210,6 +211,7 @@ public class CassandraPathDB
         pathMap.setFileSystem( fileSystem );
         String parentPath = getParentPath( path );
         String filename = getFilename( path );
+        pathMap.setSubSystem( calculateSubsystem( parentPath ) );
         pathMap.setParentPath( parentPath );
         pathMap.setFilename( filename );
         pathMap.setCreation( date );
@@ -284,7 +286,7 @@ public class CassandraPathDB
         String parentPath = getParentPath( path );
         String filename = getFilename( path ) + "/";
 
-        BoundStatement bound = preparedSingleExistQuery.bind( fileSystem, parentPath, filename );
+        BoundStatement bound = preparedSingleExistQuery.bind( fileSystem, calculateSubsystem( parentPath ), parentPath, filename );
         ResultSet result = session.execute( bound );
         long count = result.one().get( 0, Long.class );
         return count > 0;
@@ -300,7 +302,7 @@ public class CassandraPathDB
         String parentPath = getParentPath( path );
         String filename = getFilename( path );
 
-        BoundStatement bound = preparedSingleExistQuery.bind( fileSystem, parentPath, filename );
+        BoundStatement bound = preparedSingleExistQuery.bind( fileSystem, calculateSubsystem( parentPath ), parentPath, filename );
         ResultSet result = session.execute( bound );
         long count = result.one().get( 0, Long.class );
         return count > 0;
@@ -324,7 +326,7 @@ public class CassandraPathDB
         }
 
         logger.debug( "Delete pathMap, {}", pathMap );
-        pathMapMapper.delete( pathMap.getFileSystem(), pathMap.getParentPath(), pathMap.getFilename() );
+        pathMapMapper.delete( pathMap.getFileSystem(), ( (DtxPathMap) pathMap ).getSubSystem(), pathMap.getParentPath(), pathMap.getFilename() );
 
 
         ReverseMap reverseMap = deleteFromReverseMap( pathMap.getFileId(), marshall( fileSystem, path ) );
@@ -407,8 +409,9 @@ public class CassandraPathDB
         }
 
         String toFilename = getFilename( toPath );
-        pathMapMapper.save( new DtxPathMap( toFileSystem, toParentPath, toFilename, pathMap.getFileId(),
-                                            pathMap.getCreation(), pathMap.getSize(), pathMap.getFileStorage(), pathMap.getChecksum() ) );
+        pathMapMapper.save( new DtxPathMap( toFileSystem, calculateSubsystem( toParentPath ), toParentPath, toFilename,
+                                            pathMap.getFileId(), pathMap.getCreation(), pathMap.getSize(),
+                                            pathMap.getFileStorage(), pathMap.getChecksum() ) );
         return true;
     }
 
@@ -429,7 +432,7 @@ public class CassandraPathDB
         String parentPath = getParentPath( path );
         String filename = getFilename( path );
 
-        BoundStatement bound = preparedSingleExistQuery.bind( fileSystem, parentPath, filename );
+        BoundStatement bound = preparedSingleExistQuery.bind( fileSystem, calculateSubsystem( parentPath ), parentPath, filename );
         ResultSet result = session.execute( bound );
         long count = result.one().get( 0, Long.class );
         if ( count > 0 )
@@ -440,12 +443,14 @@ public class CassandraPathDB
 
         DtxPathMap pathMap = new DtxPathMap();
         pathMap.setFileSystem( fileSystem );
+        pathMap.setSubSystem( calculateSubsystem( parentPath ) );
         pathMap.setParentPath( parentPath );
         pathMap.setFilename( filename );
 
         final List<DtxPathMap> parents = getParentsBottomUp( pathMap, ( fSystem, pPath, fName ) -> {
             DtxPathMap p = new DtxPathMap();
             p.setFileSystem( fSystem );
+            p.setSubSystem( calculateSubsystem( pPath ) );
             p.setParentPath( pPath );
             p.setFilename( fName );
             return p;
@@ -494,6 +499,24 @@ public class CassandraPathDB
             return ret;
         }
         return ret - Duration.ofHours( gcGracePeriodInHours ).toMillis();
+    }
+
+    private static final int SUBSYSTEM_LEN = 6;
+
+    /**
+     * Return first 6 letters from md5Hex of parentPath. This makes sure the entries under same parentPath
+     * are located in same partition so the we can query/list them real quick.
+     */
+    private String calculateSubsystem( String parentPath )
+    {
+        if ( config.isSubsystemEnabled() )
+        {
+            return md5Hex( parentPath ).substring( 0, SUBSYSTEM_LEN );
+        }
+        else
+        {
+            return "DEFAULT";
+        }
     }
 
 }

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
@@ -12,8 +12,11 @@ import java.util.Objects;
 @Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
 public class DtxPathMap implements PathMap
 {
-    @PartitionKey
+    @PartitionKey(0)
     private String fileSystem;
+
+    @PartitionKey(1)
+    private String subSystem;
 
     @ClusteringColumn(0)
     private String parentPath;
@@ -40,9 +43,10 @@ public class DtxPathMap implements PathMap
     {
     }
 
-    public DtxPathMap( String fileSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage, String checksum )
+    public DtxPathMap( String fileSystem, String subSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage, String checksum )
     {
         this.fileSystem = fileSystem;
+        this.subSystem = subSystem;
         this.parentPath = parentPath;
         this.filename = filename;
         this.fileId = fileId;
@@ -100,6 +104,16 @@ public class DtxPathMap implements PathMap
     public void setFileSystem( String fileSystem )
     {
         this.fileSystem = fileSystem;
+    }
+
+    public String getSubSystem()
+    {
+        return subSystem;
+    }
+
+    public void setSubSystem( String subSystem )
+    {
+        this.subSystem = subSystem;
     }
 
     public String getParentPath()

--- a/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
@@ -22,6 +22,7 @@ public class CassandraPathDBUtils
     {
         return "CREATE TABLE IF NOT EXISTS " + keyspace + ".pathmap ("
                         + "filesystem varchar,"
+                        + "subsystem varchar,"
                         + "parentpath varchar,"
                         + "filename varchar,"
                         + "fileid varchar,"
@@ -29,7 +30,7 @@ public class CassandraPathDBUtils
                         + "size bigint,"
                         + "filestorage varchar,"
                         + "checksum varchar,"
-                        + "PRIMARY KEY (filesystem, parentpath, filename)"
+                        + "PRIMARY KEY ((filesystem, subsystem), parentpath, filename)"
                         + ");";
     }
 
@@ -62,4 +63,5 @@ public class CassandraPathDBUtils
                         + "PRIMARY KEY (checksum)"
                         + ");";
     }
+
 }


### PR DESCRIPTION
The "subsystem" in pathDB is a secret weapon designed to split repository/filesystem and avoid big partition. The details can be found in the design doc. Basically, this uses the first a few letters from hash of parentPath so that all entries under the same directory are located in same partition. 