### PR TITLE
Master revert

### DIFF
--- a/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -53,6 +53,12 @@ public class DefaultPathMappedStorageConfig
     }
 
     @Override
+    public boolean isSubsystemEnabled( String fileSystem )
+    {
+        return false;
+    }
+
+    @Override
     public String getFileChecksumAlgorithm()
     {
         return fileChecksumAlgorithm;

--- a/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -53,12 +53,6 @@ public class DefaultPathMappedStorageConfig
     }
 
     @Override
-    public boolean isSubsystemEnabled( String fileSystem )
-    {
-        return false;
-    }
-
-    @Override
     public String getFileChecksumAlgorithm()
     {
         return fileChecksumAlgorithm;

--- a/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -9,8 +9,6 @@ public interface PathMappedStorageConfig
 
     String getFileChecksumAlgorithm();
 
-    boolean isSubsystemEnabled( String fileSystem );
-
     Object getProperty( String key );
 
     int getGCBatchSize();

--- a/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -9,7 +9,7 @@ public interface PathMappedStorageConfig
 
     String getFileChecksumAlgorithm();
 
-    default boolean isSubsystemEnabled() { return true; }
+    boolean isSubsystemEnabled( String fileSystem );
 
     Object getProperty( String key );
 

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
@@ -12,13 +12,13 @@ import java.util.Objects;
 @Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
 public class DtxPathMap implements PathMap
 {
-    @PartitionKey
+    @PartitionKey(0)
     private String fileSystem;
 
-    @ClusteringColumn(0)
+    @PartitionKey(1)
     private String parentPath;
 
-    @ClusteringColumn(1)
+    @ClusteringColumn
     private String filename;
 
     @Column

--- a/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/datastax/model/DtxPathMap.java
@@ -12,11 +12,8 @@ import java.util.Objects;
 @Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
 public class DtxPathMap implements PathMap
 {
-    @PartitionKey(0)
+    @PartitionKey
     private String fileSystem;
-
-    @PartitionKey(1)
-    private String subSystem;
 
     @ClusteringColumn(0)
     private String parentPath;
@@ -43,10 +40,9 @@ public class DtxPathMap implements PathMap
     {
     }
 
-    public DtxPathMap( String fileSystem, String subSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage, String checksum )
+    public DtxPathMap( String fileSystem, String parentPath, String filename, String fileId, Date creation, long size, String fileStorage, String checksum )
     {
         this.fileSystem = fileSystem;
-        this.subSystem = subSystem;
         this.parentPath = parentPath;
         this.filename = filename;
         this.fileId = fileId;
@@ -104,16 +100,6 @@ public class DtxPathMap implements PathMap
     public void setFileSystem( String fileSystem )
     {
         this.fileSystem = fileSystem;
-    }
-
-    public String getSubSystem()
-    {
-        return subSystem;
-    }
-
-    public void setSubSystem( String subSystem )
-    {
-        this.subSystem = subSystem;
     }
 
     public String getParentPath()

--- a/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
@@ -29,7 +29,7 @@ public class CassandraPathDBUtils
                         + "size bigint,"
                         + "filestorage varchar,"
                         + "checksum varchar,"
-                        + "PRIMARY KEY (filesystem, parentpath, filename)"
+                        + "PRIMARY KEY ((filesystem, parentpath), filename)"
                         + ");";
     }
 

--- a/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
+++ b/src/main/java/org/commonjava/storage/pathmapped/util/CassandraPathDBUtils.java
@@ -22,7 +22,6 @@ public class CassandraPathDBUtils
     {
         return "CREATE TABLE IF NOT EXISTS " + keyspace + ".pathmap ("
                         + "filesystem varchar,"
-                        + "subsystem varchar,"
                         + "parentpath varchar,"
                         + "filename varchar,"
                         + "fileid varchar,"
@@ -30,7 +29,7 @@ public class CassandraPathDBUtils
                         + "size bigint,"
                         + "filestorage varchar,"
                         + "checksum varchar,"
-                        + "PRIMARY KEY ((filesystem, subsystem), parentpath, filename)"
+                        + "PRIMARY KEY (filesystem, parentpath, filename)"
                         + ");";
     }
 
@@ -63,5 +62,4 @@ public class CassandraPathDBUtils
                         + "PRIMARY KEY (checksum)"
                         + ");";
     }
-
 }


### PR DESCRIPTION
This pr reverts the "subsystem" partition key. I figured out if we abandon the "non-subsystemed" repo config, we can just use parentpath as the second partition key. This removes a lot of complexity. The old "non-subsystemed" was for listing small repos fast. But as they are small, they don't need special perf tune. Such a design is abandoned. 