### PR TITLE
Add checksum to Reclaim table in order to check something easily

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -260,7 +260,7 @@ public class CassandraPathDB
                 ( (DtxPathMap) pathMap ).setChecksum( existedChecksum.getChecksum() );
                 // Need to mark the generated file storage path as reclaimed to remove it.
                 final String deprecatedFileId = PathMapUtils.getRandomFileId();
-                reclaim( deprecatedFileId, deprecatedStorage );
+                reclaim( deprecatedFileId, deprecatedStorage, checksum );
             }
             else
             {
@@ -349,7 +349,7 @@ public class CassandraPathDB
             }
 
             // reclaim, but not remove from reverse table immediately (for race-detection/double-check)
-            reclaim( fileId, pathMap.getFileStorage() );
+            reclaim( fileId, pathMap.getFileStorage(), checksum.getChecksum() );
 
         }
         return true;
@@ -369,9 +369,9 @@ public class CassandraPathDB
         session.execute( "UPDATE " + keyspace + ".reversemap SET paths = paths + {'" + path + "'} WHERE fileid=?;", fileId );
     }
 
-    private void reclaim( String fileId, String fileStorage )
+    private void reclaim( String fileId, String fileStorage, String checksum )
     {
-        DtxReclaim reclaim = new DtxReclaim( fileId, new Date(), fileStorage );
+        DtxReclaim reclaim = new DtxReclaim( fileId, new Date(), fileStorage, checksum );
         logger.debug( "Reclaim, {}", reclaim );
         reclaimMapper.save( reclaim );
     }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxReclaim.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxReclaim.java
@@ -22,17 +22,21 @@ public class DtxReclaim implements Reclaim
     private String fileId;
 
     @Column
+    private String checksum;
+
+    @Column
     private String storage;
 
     public DtxReclaim()
     {
     }
 
-    public DtxReclaim( String fileId, Date deletion, String storage )
+    public DtxReclaim( String fileId, Date deletion, String storage, String checksum )
     {
         this.fileId = fileId;
         this.deletion = deletion;
         this.storage = storage;
+        this.checksum = checksum;
     }
 
     public int getPartition()
@@ -77,6 +81,16 @@ public class DtxReclaim implements Reclaim
         this.storage = storage;
     }
 
+    public String getChecksum()
+    {
+        return checksum;
+    }
+
+    public void setChecksum( String checksum )
+    {
+        this.checksum = checksum;
+    }
+
     @Override
     public boolean equals( Object o )
     {
@@ -98,6 +112,6 @@ public class DtxReclaim implements Reclaim
     public String toString()
     {
         return "DtxReclaim{" + "partition=" + partition + ", deletion=" + deletion + ", fileId='" + fileId + '\''
-                        + ", storage='" + storage + '\'' + '}';
+                        + ", checksum='" + checksum + '\'' + ", storage='" + storage + '\'' + '}';
     }
 }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -48,6 +48,7 @@ public class CassandraPathDBUtils
                         + "partition int,"
                         + "deletion timestamp,"
                         + "fileid varchar,"
+                        + "checksum varchar,"
                         + "storage varchar,"
                         + "PRIMARY KEY (partition, deletion, fileid)"
                         + ");";


### PR DESCRIPTION
Add checksum to reclaim table so we can check the migration result easily. I tested and got a half of dup files ( 20000 out of 40000).