### PR TITLE
Use sha256 for default checksum algo

### DIFF
--- a/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -11,7 +11,7 @@ public class DefaultPathMappedStorageConfig
 
     private final int DEFAULT_GC_GRACE_PERIOD_IN_HOURS = 24;
 
-    private final String DEFAULT_FILE_CHECKSUM_ALGORITHM = "MD5";
+    private final String DEFAULT_FILE_CHECKSUM_ALGORITHM = "SHA-256";
 
     private int gcGracePeriodInHours = DEFAULT_GC_GRACE_PERIOD_IN_HOURS;
 


### PR DESCRIPTION
MD5/sha1 collision has been found or compromised. Sha256 is not. Use the sha256 for default. 
I did a perf test:
For big file like 80M indy-skinny.jar, time sha256sum is 0.288s, time md5sum is 0.187s
For smaller file like 80K galley-core.jar, they both use 0.005s

