### PR TITLE
NOS-2289 fix mismatch from db entries and physical path

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PhysicalStore.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PhysicalStore.java
@@ -27,5 +27,7 @@ public interface PhysicalStore
 
     InputStream getInputStream( String storageFile ) throws IOException;
 
+    boolean exists( String storageFile );
+
     boolean delete( FileInfo fileInfo );
 }

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
@@ -106,4 +106,13 @@ public class FileBasedPhysicalStore implements PhysicalStore
         return true;
     }
 
+    @Override
+    public boolean exists( String storageFile )
+    {
+        if ( storageFile == null )
+        {
+            return false;
+        }
+        return new File( baseDir, storageFile ).exists();
+    }
 }


### PR DESCRIPTION
Found that there are some mismatch between database entries and physical store files.
There are entries in database, but for some reasons the corresponding physical files
 missed in physical location. So I think we need to check real existence of from physical
level but not just from db level to make sure if it really exists.