### PR TITLE
Insert only when no io error

### DIFF
--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 
+import static java.util.Objects.isNull;
+
 public class PathDBOutputStream
                 extends FilterOutputStream
 {
@@ -44,6 +46,8 @@ public class PathDBOutputStream
     private final String fileStorage;
 
     private long size;
+
+    private Exception error;
 
     private final ChecksumCalculator checksumCalculator;
 
@@ -77,6 +81,7 @@ public class PathDBOutputStream
         {
             // the generated physical file should be deleted immediately
             physicalStore.delete( fileInfo );
+            error = e;
             throw e;
         }
     }
@@ -85,6 +90,9 @@ public class PathDBOutputStream
     public void close() throws IOException
     {
         super.close();
-        pathDB.insert( fileSystem, path, new Date(), fileId, size, fileStorage, checksumCalculator.getDigestHex() );
+        if ( isNull( error ) )
+        {
+            pathDB.insert( fileSystem, path, new Date(), fileId, size, fileStorage, checksumCalculator.getDigestHex() );
+        }
     }
 }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ErrorIOTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ErrorIOTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static junit.framework.TestCase.fail;
+
+public class ErrorIOTest
+                extends AbstractCassandraFMTest
+{
+    private final String TEST_FS = "test";
+
+    private final String errPath = "io/err.out";
+
+    @Test
+    public void writeFileError() throws Exception
+    {
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, errPath ))
+        {
+            Assert.assertNotNull( os );
+            IOUtils.write( simpleContent.getBytes(), os );
+            FieldUtils.writeField( os, "error", new IOException(), true );
+        }
+
+        try
+        {
+            try (InputStream is = fileManager.openInputStream( TEST_FS, errPath ))
+            {
+            }
+            fail();
+        }
+        catch ( IOException ex )
+        {
+            //java.io.IOException: Could not open input stream to for path test - io/err.out: path-mapped physical file does not exist.
+            System.out.println( ex );
+        }
+    }
+
+    @Override
+    protected void clearData()
+    {
+        super.clearData();
+        fileManager.delete( TEST_FS, errPath );
+    }
+}


### PR DESCRIPTION
There is a hole that an IO error happens but path DB goes on to insert the records during the close(). I am not sure whether this caused the physical file not found issue. Anyway, I fixed this by adding a check. 