### PR TITLE
Insert only when file size larger than 0

### DIFF
--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathDBOutputStream.java
@@ -90,7 +90,7 @@ public class PathDBOutputStream
     public void close() throws IOException
     {
         super.close();
-        if ( isNull( error ) )
+        if ( isNull( error ) && size > 0 )
         {
             pathDB.insert( fileSystem, path, new Date(), fileId, size, fileStorage, checksumCalculator.getDigestHex() );
         }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ErrorIOTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ErrorIOTest.java
@@ -33,6 +33,8 @@ public class ErrorIOTest
 
     private final String errPath = "io/err.out";
 
+    private final String nullPath = "io/null.out";
+
     @Test
     public void writeFileError() throws Exception
     {
@@ -53,6 +55,27 @@ public class ErrorIOTest
         catch ( IOException ex )
         {
             //java.io.IOException: Could not open input stream to for path test - io/err.out: path-mapped physical file does not exist.
+            System.out.println( ex );
+        }
+    }
+
+    @Test
+    public void writeNothing() throws Exception
+    {
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, nullPath ))
+        {
+        }
+
+        try
+        {
+            try (InputStream is = fileManager.openInputStream( TEST_FS, nullPath ))
+            {
+            }
+            fail();
+        }
+        catch ( IOException ex )
+        {
+            //java.io.IOException: Could not open input stream to for path test - io/null.out: path-mapped physical file does not exist.
             System.out.println( ex );
         }
     }


### PR DESCRIPTION
Fix another hole that could cause physical file not found issue. Do not insert if no bytes were really written.