### PR TITLE
Add config for dedup pattern

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -24,6 +24,8 @@ public interface PathMappedStorageConfig
 
     String getFileChecksumAlgorithm();
 
+    String getDeduplicatePattern();
+
     Object getProperty( String key );
 
     int getGCBatchSize();

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -36,6 +36,8 @@ public class DefaultPathMappedStorageConfig
 
     private String fileChecksumAlgorithm = DEFAULT_FILE_CHECKSUM_ALGORITHM;
 
+    private String deduplicatePattern;
+
     public DefaultPathMappedStorageConfig()
     {
     }
@@ -99,5 +101,16 @@ public class DefaultPathMappedStorageConfig
     public void setGcBatchSize( int gcBatchSize )
     {
         this.gcBatchSize = gcBatchSize;
+    }
+
+    @Override
+    public String getDeduplicatePattern()
+    {
+        return deduplicatePattern;
+    }
+
+    public void setDeduplicatePattern( String deduplicatePattern )
+    {
+        this.deduplicatePattern = deduplicatePattern;
     }
 }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
@@ -107,6 +107,7 @@ public abstract class AbstractCassandraFMTest
         config = new DefaultPathMappedStorageConfig( props );
         // In test, we should let gc happened immediately when triggered.
         config.setGcGracePeriodInHours( 0 );
+        config.setDeduplicatePattern( "^(generic|npm|test).*" );
         pathDB = new CassandraPathDB( config );
 
     }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ChecksumDedupeTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ChecksumDedupeTest.java
@@ -53,6 +53,26 @@ public class ChecksumDedupeTest
     }
 
     @Test
+    public void checksumNotDupe_patternNotMatch()
+                    throws Exception
+    {
+        String fileSystem = "maven:hosted:test";
+
+        writeWithContent( fileSystem, path1, simpleContent );
+        writeWithContent( fileSystem, path2, simpleContent );
+
+        final String pathStorage1 = fileManager.getFileStoragePath( fileSystem, path1 );
+        final String pathStorage2 = fileManager.getFileStoragePath( fileSystem, path2 );
+
+        Assert.assertThat( pathStorage1, CoreMatchers.not( pathStorage2 ) );
+
+        checkPhysicalFile( 2, 2, pathStorage1, pathStorage2 );
+
+        checkRead( fileSystem, path1, true, simpleContent );
+        checkRead( fileSystem, path2, true, simpleContent );
+    }
+
+    @Test
     public void checksumNotDupe()
             throws Exception
     {


### PR DESCRIPTION
Fine tune the dedup behavior by pattern to control what file system should be dedupped. The test case explains the usage. Basically we want dedup for generic and npm, but not maven.