### PR TITLE
Set pathmap write consistency level to ALL

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -17,6 +17,7 @@ package org.commonjava.storage.pathmapped.pathdb.datastax;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
@@ -470,7 +471,7 @@ public class CassandraPathDB
             }
         }
 
-        pathMapMapper.save( (DtxPathMap) pathMap );
+        pathMapMapper.save( (DtxPathMap) pathMap, Mapper.Option.consistencyLevel( ConsistencyLevel.ALL ) );
 
         // insert reverse mapping and path table
         addToReverseMap( pathMap.getFileId(), PathMapUtils.marshall( fileSystem, path ) );

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
@@ -24,7 +24,7 @@ import org.commonjava.storage.pathmapped.model.PathMap;
 import java.util.Date;
 import java.util.Objects;
 
-@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "ALL" )
 public class DtxPathMap implements PathMap
 {
     @PartitionKey(0)


### PR DESCRIPTION
This is to fix the folo 0 size (and checksum missing) bug. The problem should have come from the digest and the transfer.exists() return false. 
This sounds not possible because the file was uploaded successfully and the digest was triggered by FileStoreEvent which is after the pathdb insertion. 
However, this could happen if the one of the replica have not updated the target record yet. Because the write-consistency is QUORUM. In our case, the replia factor is 3, and QUORUM is 2. ATM, the exist check hit this replica. In this case, the replica will return false. 
This fix change the level to ALL that will force the write operations to finish until all the replica are updated.