### PR TITLE
Set the read consistency level to ONE

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
@@ -24,7 +24,7 @@ import org.commonjava.storage.pathmapped.model.PathMap;
 import java.util.Date;
 import java.util.Objects;
 
-@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "ALL" )
+@Table( name = "pathmap", readConsistency = "ONE", writeConsistency = "ALL" )
 public class DtxPathMap implements PathMap
 {
     @PartitionKey(0)


### PR DESCRIPTION
We can lower down the read consistency to ONE to speed up the read. Since we already set write consistency to ALL, this won't lose any consistency.