### PR TITLE
Improve exists() via commonFileExtensions

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -29,4 +29,6 @@ public interface PathMappedStorageConfig
     Object getProperty( String key );
 
     int getGCBatchSize();
+
+    String getCommonFileExtensions();
 }

--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -39,6 +39,8 @@ public interface PathDB
 
     FileType exists( String fileSystem, String path );
 
+    boolean existsFile( String fileSystem, String path );
+
     void insert( String fileSystem, String path, Date creation, Date expiration, String fileId, long size, String fileStorage, String checksum );
 
     boolean isDirectory( String fileSystem, String path );

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
@@ -120,6 +120,12 @@ public class JPAPathDB
     }
 
     @Override
+    public boolean existsFile( String fileSystem, String path )
+    {
+        return exists( fileSystem, path ) != null;
+    }
+
+    @Override
     public void insert( String fileSystem, String path, Date creation, Date expiration, String fileId, long size, String fileStorage, String checksum )
     {
         JpaPathMap pathMap = new JpaPathMap();

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -38,6 +38,10 @@ public class DefaultPathMappedStorageConfig
 
     private String deduplicatePattern;
 
+    private static final String DEFAULT_COMMON_FILE_EXTENSIONS = ".+\\.(jar|xml|pom|gz|md5|sha1|sha256)$";
+
+    private String commonFileExtensions = DEFAULT_COMMON_FILE_EXTENSIONS;
+
     public DefaultPathMappedStorageConfig()
     {
     }
@@ -112,5 +116,16 @@ public class DefaultPathMappedStorageConfig
     public void setDeduplicatePattern( String deduplicatePattern )
     {
         this.deduplicatePattern = deduplicatePattern;
+    }
+
+    @Override
+    public String getCommonFileExtensions()
+    {
+        return commonFileExtensions;
+    }
+
+    public void setCommonFileExtensions( String commonFileExtensions )
+    {
+        this.commonFileExtensions = commonFileExtensions;
     }
 }

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -247,17 +247,20 @@ public class PathMappedFileManager implements Closeable
             return false;
         }
 
+        // we used to check the physical file during exist check. Here we ignore it because pathDB should be the
+        // only source-of-truth. If pathDB entry exists but physical file missing, that is a bug and IOException is thrown.
+        // we will run this code to see if any problem. ruhan Apr 20, 2020
+
         if ( commonFileExtensions != null && path.matches( commonFileExtensions ) )
         {
-            // we used to check the physical file during exist check. Here we ignore it because pathDB should be the
-            // only source-of-truth. If pathDB entry exists but physical file missing, that is a bug and IOException is thrown.
-            // we will run this code to see if any problem. ruhan Apr 20, 2020
             return pathDB.existsFile( fileSystem, path );
         }
 
         PathDB.FileType exist = pathDB.exists( fileSystem, path );
         if ( exist != null )
         {
+            return true;
+/*
             if ( exist == PathDB.FileType.dir )
             {
                 return true;
@@ -277,6 +280,7 @@ public class PathMappedFileManager implements Closeable
                     return false;
                 }
             }
+*/
         }
         return false;
     }

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -52,6 +52,8 @@ public class PathMappedFileManager implements Closeable
 
     private final PathMappedStorageConfig config;
 
+    private final String commonFileExtensions;
+
     private ScheduledExecutorService gcThreadPool;
 
     private String deduplicatePattern;
@@ -77,6 +79,8 @@ public class PathMappedFileManager implements Closeable
         }
 
         deduplicatePattern = config.getDeduplicatePattern();
+
+        commonFileExtensions = config.getCommonFileExtensions();
     }
 
     public Set<String> getFileSystemContainingDirectory( Collection<String> candidates, String path )
@@ -242,6 +246,12 @@ public class PathMappedFileManager implements Closeable
         {
             return false;
         }
+
+        if ( commonFileExtensions != null && path.matches( commonFileExtensions ) )
+        {
+            return pathDB.existsFile( fileSystem, path );
+        }
+
         PathDB.FileType exist = pathDB.exists( fileSystem, path );
         if ( exist != null )
         {

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -270,10 +270,15 @@ public class PathMappedFileManager implements Closeable
 
         if ( exists )
         {
-            // check expiration and physical file
+            // check expiration
             String storageFile = pathDB.getStorageFile( fileSystem, path );
             if ( storageFile != null )
             {
+                return true;
+                // we used to check the physical file during exist check. Here we ignore it because pathDB should be the
+                // only source-of-truth. If pathDB entry exists but physical file missing, that is a bug and IOException is thrown.
+                // we will run this code to see if any problem. ruhan Apr 20, 2020
+/*
                 if ( physicalStore.exists( storageFile ) )
                 {
                     return true;
@@ -284,6 +289,7 @@ public class PathMappedFileManager implements Closeable
                                  fileSystem, path, storageFile );
                     return false;
                 }
+*/
             }
         }
         return false;

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -249,6 +249,9 @@ public class PathMappedFileManager implements Closeable
 
         if ( commonFileExtensions != null && path.matches( commonFileExtensions ) )
         {
+            // we used to check the physical file during exist check. Here we ignore it because pathDB should be the
+            // only source-of-truth. If pathDB entry exists but physical file missing, that is a bug and IOException is thrown.
+            // we will run this code to see if any problem. ruhan Apr 20, 2020
             return pathDB.existsFile( fileSystem, path );
         }
 

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
@@ -78,6 +78,12 @@ public class MeasuredPathDB
     }
 
     @Override
+    public boolean existsFile( String fileSystem, String path )
+    {
+        return measure( () -> decorated.existsFile( fileSystem, path ), "existsFile" );
+    }
+
+    @Override
     public void insert( String fileSystem, String path, Date creation, Date expiration, String fileId, long size, String fileStorage,
                         String checksum )
     {

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SimpleIOTest
@@ -60,6 +61,22 @@ public class SimpleIOTest
             String result = new String( IOUtils.toByteArray( is ), Charset.defaultCharset() );
             Assert.assertThat( result, CoreMatchers.equalTo( simpleContent ) );
         }
+    }
+
+    @Test
+    public void commonFileExtensionTest()
+                    throws Exception
+    {
+        String gzFile = "/foo/bar/1.0/bar-1.0.tar.gz"; // .gz is in common file extension
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, gzFile ))
+        {
+            Assert.assertNotNull( os );
+            IOUtils.write( simpleContent.getBytes(), os );
+        }
+        assertTrue( fileManager.exists( TEST_FS, gzFile ) );
+
+        String notExistsFile = "/foo/bar/2.0/bar-2.0.tar.gz";
+        assertFalse( fileManager.exists( TEST_FS, notExistsFile ) );
     }
 
     @Test


### PR DESCRIPTION
If path ends with specific extensions, we know it is file. We can improve exists() performance to mitigate the timeout problem.