### PR TITLE
Lower addToReverseMap ConsistencyLevel to ONE

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -562,7 +562,11 @@ public class CassandraPathDB
     private void addToReverseMap( String fileId, String path )
     {
         logger.debug( "Add to reverseMap, fileId: {}, path: {}", fileId, path );
-        session.execute( "UPDATE " + keyspace + ".reversemap SET paths = paths + {'" + path + "'} WHERE fileid=?;", fileId );
+        PreparedStatement prepared = session.prepare(
+                        "UPDATE " + keyspace + ".reversemap SET paths = paths + {'" + path + "'} WHERE fileid=?;" );
+        prepared.setConsistencyLevel( ConsistencyLevel.ONE );
+        BoundStatement bound = prepared.bind( fileId );
+        session.execute( bound );
     }
 
     private void reclaim( String fileId, String fileStorage, String checksum )


### PR DESCRIPTION
One timeout happened during insert to reversemap. We should lower the write consistency with this low priority operation. Ref:  http://pastebin.test.redhat.com/856592