### PR TITLE
Restore write consistent level to QUORUM

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -503,7 +503,7 @@ public class CassandraPathDB
             }
         }
 
-        pathMapMapper.save( (DtxPathMap) pathMap, Mapper.Option.consistencyLevel( ConsistencyLevel.ALL ) );
+        pathMapMapper.save( (DtxPathMap) pathMap );
 
         // insert reverse mapping and path table
         addToReverseMap( pathMap.getFileId(), PathMapUtils.marshall( fileSystem, path ) );

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
@@ -24,7 +24,7 @@ import org.commonjava.storage.pathmapped.model.PathMap;
 import java.util.Date;
 import java.util.Objects;
 
-@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "ALL" )
+@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
 public class DtxPathMap implements PathMap
 {
     @PartitionKey(0)


### PR DESCRIPTION
To fix: com.datastax.driver.core.exceptions.WriteTimeoutException: Cassandra timeout during SIMPLE write query at consistency ALL (3 replica were required but only 2 acknowledged the write)
We have been too aggresive in terms of writing. 