### PR TITLE
Use more efficient method calls for writing to a stream.

### DIFF
--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -25,6 +25,7 @@ import org.commonjava.storage.pathmapped.spi.PhysicalStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -135,10 +136,11 @@ public class PathMappedFileManager implements Closeable
         }
         try
         {
-            return new PathDBOutputStream( pathDB, physicalStore, fileSystem, path, fileInfo,
+            return new BufferedOutputStream( new PathDBOutputStream( pathDB, physicalStore,
+                                           fileSystem, path, fileInfo,
                                            physicalStore.getOutputStream( fileInfo ),
                                            checksumAlgorithm,
-                                           timeoutUnit.toMillis( timeout ));
+                                           timeoutUnit.toMillis( timeout )) );
         }
         catch ( NoSuchAlgorithmException e )
         {

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/util/ChecksumCalculator.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/util/ChecksumCalculator.java
@@ -17,6 +17,9 @@ package org.commonjava.storage.pathmapped.util;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
 
@@ -26,10 +29,20 @@ public class ChecksumCalculator
 
     private String digestHex;
 
+    private static Provider provider;
+
     public ChecksumCalculator( final String algorithm )
             throws NoSuchAlgorithmException
     {
-        this.digester = MessageDigest.getInstance( algorithm );
+        if (provider == null)
+        {
+            this.digester = MessageDigest.getInstance( algorithm );
+            this.provider = this.digester.getProvider();
+        }
+        else
+        {
+            this.digester = MessageDigest.getInstance( algorithm, this.provider );
+        }
     }
 
     public final void update( final byte[] data )
@@ -40,6 +53,11 @@ public class ChecksumCalculator
     public final void update( final byte data )
     {
         digester.update( data );
+    }
+
+    public final void update( final byte[] data, final int offset, final int len )
+    {
+        digester.update( data, offset, len );
     }
 
     public synchronized String getDigestHex()

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ErrorIOTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ErrorIOTest.java
@@ -20,9 +20,12 @@ import org.apache.commons.lang.reflect.FieldUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
+import org.commonjava.storage.pathmapped.core.PathDBOutputStream;
 
 import static junit.framework.TestCase.fail;
 
@@ -40,9 +43,13 @@ public class ErrorIOTest
     {
         try (OutputStream os = fileManager.openOutputStream( TEST_FS, errPath ))
         {
-            Assert.assertNotNull( os );
-            IOUtils.write( simpleContent.getBytes(), os );
-            FieldUtils.writeField( os, "error", new IOException(), true );
+            Object obj = FieldUtils.readField ( os, "out", true );
+            Assert.assertNotNull( obj );
+            Assert.assertTrue ( obj instanceof PathDBOutputStream );
+            PathDBOutputStream pathDBos = ( PathDBOutputStream) obj;
+            Assert.assertNotNull( pathDBos );
+            IOUtils.write( simpleContent.getBytes(), pathDBos );
+            FieldUtils.writeField( pathDBos, "error", new IOException(), true );
         }
 
         try


### PR DESCRIPTION
 This PR partially solves an issue that affects the efficiency storing downloaded artifacts to disk.
 There is buffering of downloaded bytes. Which simultaneously updates the digest calculator and uses bulk writing of byte array to the underlying stream that writes to file.
 This PR does not make functional changes to behaviour.