### PR TITLE
Revert the write-consistency level to ALL

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -91,7 +91,7 @@ public class CassandraPathDB
     private PreparedStatement preparedExistQuery, preparedListQuery, preparedContainingQuery, preparedExistFileQuery,
                     preparedReverseMapIncrement, preparedReverseMapReduction;
 
-    // r consistency level defaults to ONE for all write and read operations
+    // r level defaults to ONE for low latency (which is also Datastax's default behaviour for all write and read operations)
     private ConsistencyLevel pathmapReadLevel = ONE;
 
     // w level to ALL to avoid data inconsistency, because we often checks file existence right after writing

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -503,7 +503,7 @@ public class CassandraPathDB
             }
         }
 
-        pathMapMapper.save( (DtxPathMap) pathMap );
+        pathMapMapper.save( (DtxPathMap) pathMap, Mapper.Option.consistencyLevel( ConsistencyLevel.ALL ) );
 
         // insert reverse mapping and path table
         addToReverseMap( pathMap.getFileId(), PathMapUtils.marshall( fileSystem, path ) );

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -91,7 +91,7 @@ public class CassandraPathDB
     private PreparedStatement preparedExistQuery, preparedListQuery, preparedContainingQuery, preparedExistFileQuery,
                     preparedReverseMapIncrement, preparedReverseMapReduction;
 
-    // r level defaults to ONE for low latency (which is also Datastax's default behaviour for all write and read operations)
+    // r level defaults to ONE for low latency (which is also Datastax's default behaviour for all r/w operations)
     private ConsistencyLevel pathmapReadLevel = ONE;
 
     // w level to ALL to avoid data inconsistency, because we often checks file existence right after writing
@@ -156,24 +156,17 @@ public class CassandraPathDB
         preparedContainingQuery = session.prepare( "SELECT filesystem FROM " + keyspace
                                                                    + ".pathmap WHERE filesystem IN ? and parentpath=? and filename=?;" );
 
-        preparedReverseMapIncrement =
-                        session.prepare( "UPDATE " + keyspace + ".reversemap SET paths = paths + ? WHERE fileid=?;" );
-
-        preparedReverseMapReduction =
-                        session.prepare( "UPDATE " + keyspace + ".reversemap SET paths = paths - ? WHERE fileid=?;" );
-
-        setConsistencyLevels();
-    }
-
-    private void setConsistencyLevels()
-    {
         preparedExistFileQuery.setConsistencyLevel( pathmapReadLevel );
         preparedExistQuery.setConsistencyLevel( pathmapReadLevel );
         preparedListQuery.setConsistencyLevel( pathmapReadLevel );
         preparedContainingQuery.setConsistencyLevel( pathmapReadLevel );
 
-        // Set w level to ONE for reverse table because this is not in critical path
+        preparedReverseMapIncrement =
+                        session.prepare( "UPDATE " + keyspace + ".reversemap SET paths = paths + ? WHERE fileid=?;" );
         preparedReverseMapIncrement.setConsistencyLevel( ONE );
+
+        preparedReverseMapReduction =
+                        session.prepare( "UPDATE " + keyspace + ".reversemap SET paths = paths - ? WHERE fileid=?;" );
         preparedReverseMapReduction.setConsistencyLevel( ONE );
     }
 

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
@@ -24,7 +24,7 @@ import org.commonjava.storage.pathmapped.model.PathMap;
 import java.util.Date;
 import java.util.Objects;
 
-@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "ALL" )
 public class DtxPathMap implements PathMap
 {
     @PartitionKey(0)

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxPathMap.java
@@ -24,7 +24,7 @@ import org.commonjava.storage.pathmapped.model.PathMap;
 import java.util.Date;
 import java.util.Objects;
 
-@Table( name = "pathmap", readConsistency = "QUORUM", writeConsistency = "ALL" )
+@Table( name = "pathmap", readConsistency = "ONE", writeConsistency = "ALL" )
 public class DtxPathMap implements PathMap
 {
     @PartitionKey(0)


### PR DESCRIPTION
Revert the write-consistency level to ALL since Indy always checks the existence right after writing. We have many ways to handle write-timeout but only this way to solve the r-right-after-w problem. 