### PR TITLE
Specify replicationFactor when initiate CassandraPathDB

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -27,10 +27,13 @@ public class CassandraPathDBUtils
 
     public static final String PROP_CASSANDRA_KEYSPACE = "cassandra_keyspace";
 
-    public static String getSchemaCreateKeyspace( String keyspace )
+    public static final String PROP_CASSANDRA_REPLICATION_FACTOR = "cassandra_replication_factor";
+
+    public static String getSchemaCreateKeyspace( String keyspace, int replicationFactor )
     {
         return "CREATE KEYSPACE IF NOT EXISTS " + keyspace
-                        + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1};";
+                        + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':" + replicationFactor
+                        + "};";
     }
 
     public static String getSchemaCreateTablePathmap( String keyspace )

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <datastaxVersion>3.7.2</datastaxVersion>
         <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
         <hibernateVersion>5.4.4.Final</hibernateVersion>
-        <o11yphantVersion>1.3-SNAPSHOT</o11yphantVersion>
+        <o11yphantVersion>1.4-SNAPSHOT</o11yphantVersion>
         <h2Version>1.4.188</h2Version>
     </properties>
 


### PR DESCRIPTION
I found indy creates storage keyspace with default replica 1. This fix add the arg to the PathDB constructor, and allow Indy to be able to specify the replica.