### PR TITLE
Support layered-physicalstore

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/model/FileChecksum.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/model/FileChecksum.java
@@ -17,6 +17,8 @@ package org.commonjava.storage.pathmapped.model;
 
 public interface FileChecksum
 {
+    String getStorageLevel();
+
     String getFileId();
 
     String getChecksum();

--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -52,7 +52,16 @@ public interface PathDB
 
     String getStorageFile( String fileSystem, String path );
 
+    /**
+     * Perform db-only copy.
+     */
     boolean copy( String fromFileSystem, String fromPath, String toFileSystem, String toPath );
+
+    /**
+     * Perform hard copy.
+     * @param target hard copy target, including new fileId and new storageFile.
+     */
+    boolean copy( String fromFileSystem, String fromPath, String toFileSystem, String toPath, FileInfo target );
 
     void makeDirs( String fileSystem, String path );
 

--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PhysicalStore.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PhysicalStore.java
@@ -30,4 +30,6 @@ public interface PhysicalStore
     boolean exists( String storageFile );
 
     boolean delete( FileInfo fileInfo );
+
+    void copy( String srcFileStorage, String targetFileStorage ) throws IOException;
 }

--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/StorageClassifier.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/StorageClassifier.java
@@ -1,0 +1,34 @@
+package org.commonjava.storage.pathmapped.spi;
+
+import java.util.Objects;
+
+/**
+ * This abstract class is to classify filesystems into different storage level. An storage classifier can be passed to
+ * PathMappedFileManager, PathDB, or PhysicalStore (we exposes all the three classes to customer to get big flexibility).
+ *
+ * The storage level can be used to create cap dir for storageFile in physical store (e.g., LayeredPhysicalStore),
+ * or give hints to pathDB to control de-dup (e.g, CassandraPathDB), and PathMappedFileManager to control copy behavior.
+ *
+ * Specifically, de-dup only occurs when the (filesystem, path) tuples are on same storage level. Copying to the same
+ * level filesystem is db-only copy, and to different level filesystem will be hard copy (physical file copy).
+ */
+public abstract class StorageClassifier
+{
+    public static String DEFAULT_STORAGE_LEVEL = "level-default";
+
+    /**
+     * Get the storage level for the specified filesystem.
+     * @return storage level, e.g., level-1, l2, etc.
+     */
+    public abstract String getStorageLevel( String fileSystem );
+
+    public boolean isSameLevel( String fileSystem1, String fileSystem2 )
+    {
+        return Objects.equals( getStorageLevel( fileSystem1 ), getStorageLevel( fileSystem2 ) );
+    }
+
+    public boolean isDifferentLevel( String fileSystem1, String fileSystem2 )
+    {
+        return !isSameLevel( fileSystem1, fileSystem2 );
+    }
+}

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxFileChecksum.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxFileChecksum.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.storage.pathmapped.pathdb.datastax.model;
 
+import com.datastax.driver.mapping.annotations.ClusteringColumn;
 import com.datastax.driver.mapping.annotations.Column;
 import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
@@ -29,6 +30,9 @@ public class DtxFileChecksum
     @PartitionKey
     private String checksum;
 
+    @ClusteringColumn
+    private String storageLevel;
+
     @Column
     private String fileId;
 
@@ -39,11 +43,23 @@ public class DtxFileChecksum
     {
     }
 
-    public DtxFileChecksum( String checksum, String fileId, String storage )
+    public DtxFileChecksum( String checksum, String storageLevel, String fileId, String storage )
     {
         this.checksum = checksum;
+        this.storageLevel = storageLevel;
         this.fileId = fileId;
         this.storage = storage;
+    }
+
+    @Override
+    public String getStorageLevel()
+    {
+        return storageLevel;
+    }
+
+    public void setStorageLevel( String storageLevel )
+    {
+        this.storageLevel = storageLevel;
     }
 
     public String getFileId()
@@ -85,12 +101,12 @@ public class DtxFileChecksum
         if ( o == null || getClass() != o.getClass() )
             return false;
         DtxFileChecksum that = (DtxFileChecksum) o;
-        return checksum.equals( that.checksum );
+        return checksum.equals( that.checksum ) && storageLevel.equals( that.storageLevel );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( checksum );
+        return Objects.hash( checksum, storageLevel );
     }
 }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -77,9 +77,10 @@ public class CassandraPathDBUtils
     {
         return "CREATE TABLE IF NOT EXISTS " + keyspace + ".filechecksum ("
                         + "checksum varchar,"
+                        + "storagelevel varchar,"
                         + "fileid varchar,"
                         + "storage varchar,"
-                        + "PRIMARY KEY (checksum)"
+                        + "PRIMARY KEY (checksum, storagelevel)"
                         + ");";
     }
 }

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
@@ -23,6 +23,7 @@ import org.commonjava.storage.pathmapped.pathdb.jpa.model.JpaReverseMap;
 import org.commonjava.storage.pathmapped.model.PathMap;
 import org.commonjava.storage.pathmapped.model.Reclaim;
 import org.commonjava.storage.pathmapped.model.ReverseMap;
+import org.commonjava.storage.pathmapped.spi.FileInfo;
 import org.commonjava.storage.pathmapped.spi.PathDB;
 import org.commonjava.storage.pathmapped.util.PathMapUtils;
 import org.slf4j.Logger;
@@ -302,6 +303,12 @@ public class JPAPathDB
                                                    pathMap.getFileStorage(), "" ) );
         } );
         return true;
+    }
+
+    @Override
+    public boolean copy( String fromFileSystem, String fromPath, String toFileSystem, String toPath, FileInfo target )
+    {
+        return copy( fromFileSystem, fromPath, toFileSystem, toPath );
     }
 
     @Override

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaFileChecksum.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaFileChecksum.java
@@ -23,6 +23,8 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import java.util.Objects;
 
+import static org.commonjava.storage.pathmapped.spi.StorageClassifier.DEFAULT_STORAGE_LEVEL;
+
 @Entity
 @Table( name = "filechecksum" )
 public class JpaFileChecksum
@@ -46,6 +48,12 @@ public class JpaFileChecksum
         this.checksum = checksum;
         this.fileId = fileId;
         this.storage = storage;
+    }
+
+    @Override
+    public String getStorageLevel()
+    {
+        return DEFAULT_STORAGE_LEVEL;
     }
 
     public String getFileId()

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/FileBasedPhysicalStore.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.storage.pathmapped.core;
 
+import org.apache.commons.io.FileUtils;
 import org.commonjava.storage.pathmapped.spi.FileInfo;
 import org.commonjava.storage.pathmapped.spi.PhysicalStore;
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ public class FileBasedPhysicalStore implements PhysicalStore
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private final File baseDir;
+    protected final File baseDir;
 
     public FileBasedPhysicalStore( File baseDir )
     {
@@ -46,7 +47,7 @@ public class FileBasedPhysicalStore implements PhysicalStore
     public FileInfo getFileInfo( String fileSystem, String path )
     {
         String id = getRandomFileId();
-        String dir = getStorageDir( id );
+        String dir = getStorageDir( fileSystem, id );
         FileInfo fileInfo = new FileInfo();
         fileInfo.setFileId( id );
         fileInfo.setFileStorage( Paths.get( dir, id ).toString() );
@@ -59,7 +60,7 @@ public class FileBasedPhysicalStore implements PhysicalStore
 
     private static final int DIR_LENGTH = LEVEL_1_DIR_LENGTH + LEVEL_2_DIR_LENGTH;
 
-    private String getStorageDir( String fileId )
+    protected String getStorageDir( String fileSystem, String fileId )
     {
         String folder = fileId.substring( 0, LEVEL_1_DIR_LENGTH );
         String subFolder = fileId.substring( LEVEL_1_DIR_LENGTH, DIR_LENGTH );
@@ -104,6 +105,12 @@ public class FileBasedPhysicalStore implements PhysicalStore
             return false;
         }
         return true;
+    }
+
+    @Override
+    public void copy( String srcFileStorage, String targetFileStorage ) throws IOException
+    {
+        FileUtils.copyFile( new File( baseDir, srcFileStorage ), new File( baseDir, targetFileStorage ) );
     }
 
     @Override

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/LayeredPhysicalStore.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/LayeredPhysicalStore.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.core;
+
+import org.commonjava.storage.pathmapped.spi.StorageClassifier;
+
+import java.io.File;
+
+public class LayeredPhysicalStore
+                extends FileBasedPhysicalStore
+{
+    private StorageClassifier storageClassifier;
+
+    public LayeredPhysicalStore( StorageClassifier storageClassifier, File baseDir )
+    {
+        super( baseDir );
+        this.storageClassifier = storageClassifier;
+    }
+
+    protected String getStorageDir( String fileSystem, String fileId )
+    {
+        return storageClassifier.getStorageLevel( fileSystem ) + "/" + super.getStorageDir( fileSystem, fileId );
+    }
+
+}

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
@@ -18,9 +18,8 @@ package org.commonjava.storage.pathmapped.metrics;
 import org.commonjava.o11yphant.metrics.MetricsManager;
 import org.commonjava.storage.pathmapped.model.PathMap;
 import org.commonjava.storage.pathmapped.model.Reclaim;
+import org.commonjava.storage.pathmapped.spi.FileInfo;
 import org.commonjava.storage.pathmapped.spi.PathDB;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Date;
@@ -136,6 +135,12 @@ public class MeasuredPathDB
     public boolean copy( String fromFileSystem, String fromPath, String toFileSystem, String toPath )
     {
         return measure( () -> decorated.copy( fromFileSystem, fromPath, toFileSystem, toPath ), "copy" );
+    }
+
+    @Override
+    public boolean copy( String fromFileSystem, String fromPath, String toFileSystem, String toPath, FileInfo fileInfo )
+    {
+        return measure( () -> decorated.copy( fromFileSystem, fromPath, toFileSystem, toPath, fileInfo ), "hardCopy" );
     }
 
     @Override

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/util/PatternBasedStorageClassifier.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/util/PatternBasedStorageClassifier.java
@@ -1,0 +1,30 @@
+package org.commonjava.storage.pathmapped.util;
+
+import org.commonjava.storage.pathmapped.spi.StorageClassifier;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class PatternBasedStorageClassifier extends StorageClassifier
+{
+    // pattern -> storageLevel, e.g, "^build-.+" -> level-1, "^temp.+" -> level-2, etc
+    private final Map<Pattern, String> patternLevelMap;
+
+    public PatternBasedStorageClassifier( Map<Pattern, String> patternLevelMap )
+    {
+        this.patternLevelMap = patternLevelMap;
+    }
+
+    public String getStorageLevel( String fileSystem )
+    {
+        for ( Map.Entry<Pattern, String> entry : patternLevelMap.entrySet() )
+        {
+            if ( entry.getKey().matcher( fileSystem ).matches() )
+            {
+                return entry.getValue();
+            }
+        }
+        return DEFAULT_STORAGE_LEVEL;
+    }
+
+}

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractCassandraFMTest
     @Rule
     public TestName name = new TestName();
 
-    private static CassandraPathDB pathDB;
+    static CassandraPathDB pathDB;
 
     Session session;
 
@@ -78,7 +78,7 @@ public abstract class AbstractCassandraFMTest
 
     private String baseStoragePath;
 
-    private static DefaultPathMappedStorageConfig config;
+    static DefaultPathMappedStorageConfig config;
 
     private final String root = "/root";
 
@@ -141,12 +141,16 @@ public abstract class AbstractCassandraFMTest
     {
         File baseDir = temp.newFolder();
         baseStoragePath = baseDir.getCanonicalPath();
-        fileManager = new PathMappedFileManager( config, pathDB,
-                                                 new FileBasedPhysicalStore( baseDir ) );
+        fileManager = initiateFileManager(baseDir);
         session = pathDB.getSession();
         MappingManager manager = new MappingManager( session );
         pathMapMapper = manager.mapper( DtxPathMap.class, KEYSPACE );
         reverseMapMapper = manager.mapper( DtxReverseMap.class, KEYSPACE );
+    }
+
+    protected PathMappedFileManager initiateFileManager( File baseDir )
+    {
+        return new PathMappedFileManager( config, pathDB, new FileBasedPhysicalStore( baseDir ) );
     }
 
     @After
@@ -157,7 +161,7 @@ public abstract class AbstractCassandraFMTest
         cleanAllData();
     }
 
-    private void cleanAllData()
+    protected void cleanAllData()
     {
         if ( pathDB != null )
         {

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/StorageClassifierTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/StorageClassifierTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.storage.pathmapped.core.LayeredPhysicalStore;
+import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
+import org.commonjava.storage.pathmapped.pathdb.datastax.CassandraPathDB;
+import org.commonjava.storage.pathmapped.spi.StorageClassifier;
+import org.commonjava.storage.pathmapped.util.PatternBasedStorageClassifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+
+public class StorageClassifierTest
+                extends SimpleIOTest
+{
+    final String TEMP_1 = "temp-1";
+
+    final String TEMP_2 = "temp-2";
+
+    final String BUILD_1 = "build-1";
+
+    @Override
+    protected PathMappedFileManager initiateFileManager( File baseDir )
+    {
+        Map<Pattern, String> patternLevelMap = new HashMap<>();
+        patternLevelMap.put( Pattern.compile( "^build-.+" ), "level-1" );
+        patternLevelMap.put( Pattern.compile( "^temp-.+" ), "level-2" );
+
+        StorageClassifier storageClassifier = new PatternBasedStorageClassifier( patternLevelMap );
+
+        // Note: storageClassifier is passed to path DB, physical store, and fileManager
+        LayeredPhysicalStore layeredPhysicalStore = new LayeredPhysicalStore( storageClassifier, baseDir );
+        CassandraPathDB cassandraPathDB =
+                        new CassandraPathDB( config, pathDB.getSession(), KEYSPACE, 1, storageClassifier );
+        return new PathMappedFileManager( config, cassandraPathDB, layeredPhysicalStore, storageClassifier );
+    }
+
+    @Test
+    public void sameLevelCopy() throws IOException
+    {
+
+        assertThat( fileManager.exists( TEMP_1, path1 ), equalTo( false ) );
+        assertThat( fileManager.exists( TEMP_2, path2 ), equalTo( false ) );
+
+        writeWithContent( fileManager.openOutputStream( TEMP_1, path1 ), simpleContent );
+        fileManager.copy( TEMP_1, path1, TEMP_2, path2 );
+        assertThat( fileManager.exists( TEMP_2, path2 ), equalTo( true ) );
+
+        checkContent( TEMP_2, path2, simpleContent );
+
+        assertEquals( fileManager.getFileStoragePath( TEMP_1, path1 ),
+                      fileManager.getFileStoragePath( TEMP_2, path2 ) );
+
+    }
+
+    @Test
+    public void differentLevelCopy() throws IOException
+    {
+
+        assertThat( fileManager.exists( TEMP_1, path1 ), equalTo( false ) );
+        assertThat( fileManager.exists( BUILD_1, path2 ), equalTo( false ) );
+
+        writeWithContent( fileManager.openOutputStream( TEMP_1, path1 ), simpleContent );
+        fileManager.copy( TEMP_1, path1, BUILD_1, path2 );
+        assertThat( fileManager.exists( BUILD_1, path2 ), equalTo( true ) );
+
+        checkContent( BUILD_1, path2, simpleContent );
+
+        assertNotEquals( fileManager.getFileStoragePath( TEMP_1, path1 ),
+                         fileManager.getFileStoragePath( BUILD_1, path2 ) );
+
+    }
+
+    @Override
+    public void read1MbFile() throws Exception
+    {
+        // ignore
+    }
+
+    @Override
+    public void read11MbFile() throws Exception
+    {
+        // ignore
+    }
+
+    private void checkContent( String fs, String path, String expected ) throws IOException
+    {
+        try (InputStream is = fileManager.openInputStream( fs, path ))
+        {
+            Assert.assertNotNull( is );
+            String result = new String( IOUtils.toByteArray( is ), Charset.defaultCharset() );
+            assertThat( result, equalTo( expected ) );
+        }
+    }
+
+    @Override
+    protected void clearData()
+    {
+        super.clearData();
+        fileManager.delete( TEMP_1, path1 );
+        fileManager.delete( TEMP_2, path2 );
+        fileManager.delete( BUILD_1, path2 );
+    }
+
+}


### PR DESCRIPTION
@jdcasey this is what I mentioned today about the "layered" or classified physical storage approach. Mainly, it affects the de-dup ( a feature we not used yet ), copy ( another not-used feature ). 
It use a custom StorageClassifier to determine a "root dir" for each level files. File copy will be hard-copy only if the src and target are in different level. De-dup only happens within same level. 