### PR TITLE
Allow deleteEmptyDir

### DIFF
--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ListingTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ListingTest.java
@@ -55,6 +55,36 @@ public class ListingTest
     }
 
     @Test
+    public void deleteEmptyDirTest() throws IOException
+    {
+        String path1 = "/dir1/file1";
+        String path2 = "/file2";
+        writeWithContent( fileManager.openOutputStream( TEST_FS, path1 ), simpleContent );
+        writeWithContent( fileManager.openOutputStream( TEST_FS, path2 ), simpleContent );
+        List<String> lists = Arrays.asList( fileManager.list( TEST_FS, "/" ) );
+        Assert.assertThat( lists, CoreMatchers.hasItems( "dir1/", "file2" ) );
+
+        //List dir1
+        lists = Arrays.asList( fileManager.list( TEST_FS, "/dir1" ) );
+        Assert.assertThat( lists.size(), CoreMatchers.equalTo( 1 ) );
+        Assert.assertThat( lists, CoreMatchers.hasItems( "file1" ) );
+
+        //Delete dir1 should fail
+        boolean deleted = fileManager.delete( TEST_FS, "/dir1/" );
+        Assert.assertFalse( deleted );
+
+        //Delete file1 and empty dir1
+        fileManager.delete( TEST_FS, path1 );
+        deleted = fileManager.delete( TEST_FS, "/dir1/" ); // it will be taken as file if no trailing '/'
+        Assert.assertTrue( deleted );
+
+        //Only file2 left
+        lists = Arrays.asList( fileManager.list( TEST_FS, "/" ) );
+        Assert.assertThat( lists.size(), CoreMatchers.equalTo( 1 ) );
+        Assert.assertThat( lists, CoreMatchers.hasItems( "file2" ) );
+    }
+
+    @Test
     public void listEntriesInDiffFolders()
             throws IOException
     {

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/SimpleIOTest.java
@@ -259,11 +259,11 @@ public class SimpleIOTest
         {
             Assert.assertThat( is, CoreMatchers.notNullValue() );
         }
-        Assert.assertThat( fileManager.delete( TEST_FS, path1 ), CoreMatchers.equalTo( true ) );
-        assertNonExistsOpen( TEST_FS, path1 );
-        //NOTE: not allow to delete a folder
+        //NOTE: not allow to delete a non-empty folder
         Assert.assertThat( fileManager.delete( TEST_FS, pathSub1 + "/" ), CoreMatchers.equalTo( false ) );
         assertPathWithChecker( ( f, p ) -> fileManager.exists( f, p ), TEST_FS, pathSub1, true );
+        Assert.assertThat( fileManager.delete( TEST_FS, path1 ), CoreMatchers.equalTo( true ) );
+        assertNonExistsOpen( TEST_FS, path1 );
     }
 
     private void assertNonExistsOpen( final String fileSystem, final String path){


### PR DESCRIPTION
When browsing dirs, I found indy keeps reporting a lot of INFO, e.g, "Delete empty folder, maven:hosted:pnc-builds/com/github/michalszynkiewicz/test/empty/1.0.0.redhat-00001/". See http://pastebin.test.redhat.com/1017725
But the folder is not really deleted because pathmap db not allow it (ignored).
I add this fix to allow removing empty folders.
