### PR TITLE
Support basic filesystem information

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/model/Filesystem.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/model/Filesystem.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.model;
+
+public interface Filesystem
+{
+    String getFilesystem();
+
+    Long getFileCount();
+
+    Long getSize();
+}

--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDBAdmin.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDBAdmin.java
@@ -1,0 +1,8 @@
+package org.commonjava.storage.pathmapped.spi;
+
+import org.commonjava.storage.pathmapped.model.Filesystem;
+
+public interface PathDBAdmin
+{
+    Filesystem getFilesystem(String filesystem);
+}

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxFilesystem.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxFilesystem.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.pathdb.datastax.model;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.commonjava.storage.pathmapped.model.Filesystem;
+
+import java.util.Objects;
+
+@Table( name = "filesystem", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxFilesystem implements Filesystem
+{
+    @PartitionKey
+    private String filesystem;
+
+    @Column
+    private long fileCount;
+
+    @Column
+    private long size;
+
+    public DtxFilesystem()
+    {
+    }
+
+    public DtxFilesystem(String filesystem, long fileCount, long size) {
+        this.filesystem = filesystem;
+        this.fileCount = fileCount;
+        this.size = size;
+    }
+
+    @Override
+    public String getFilesystem() {
+        return filesystem;
+    }
+
+    @Override
+    public Long getFileCount() {
+        return fileCount;
+    }
+
+    @Override
+    public Long getSize() {
+        return size;
+    }
+
+    public void setFilesystem(String filesystem) {
+        this.filesystem = filesystem;
+    }
+
+    public void setFileCount(long fileCount) {
+        this.fileCount = fileCount;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DtxFilesystem that = (DtxFilesystem) o;
+        return filesystem.equals(that.filesystem);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filesystem);
+    }
+
+    @Override
+    public String toString() {
+        return "DtxFilesystem{" +
+                "filesystem='" + filesystem + '\'' +
+                ", fileCount=" + fileCount +
+                ", size=" + size +
+                '}';
+    }
+}

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -36,6 +36,22 @@ public class CassandraPathDBUtils
                         + "};";
     }
 
+    /*
+     * 'filesystem' table provides basic file count and total size of this filesystem.
+     * A counter is a 64-bit signed integer and on which only 2 operations are supported: incrementing and decrementing.
+     * Table that contains a counter can only contain counters. In other words, either all the columns of a table
+     * outside the PRIMARY KEY have the counter type, or none of them have it.
+     */
+    public static String getSchemaCreateTableFilesystem( String keyspace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".filesystem ("
+                + "filesystem varchar,"
+                + "filecount counter,"
+                + "size counter,"
+                + "PRIMARY KEY (filesystem)"
+                + ");";
+    }
+
     public static String getSchemaCreateTablePathmap( String keyspace )
     {
         return "CREATE TABLE IF NOT EXISTS " + keyspace + ".pathmap ("

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <javaVersion>1.8</javaVersion>
         <test-forkCount>1</test-forkCount>
         <datastaxVersion>3.7.2</datastaxVersion>
-        <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
+        <cassandraUnitVersion>3.11.2.0</cassandraUnitVersion>
         <hibernateVersion>5.4.4.Final</hibernateVersion>
         <o11yphantVersion>1.4</o11yphantVersion>
         <h2Version>1.4.188</h2Version>

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -16,10 +16,12 @@
 package org.commonjava.storage.pathmapped.core;
 
 import org.commonjava.storage.pathmapped.config.PathMappedStorageConfig;
+import org.commonjava.storage.pathmapped.model.Filesystem;
 import org.commonjava.storage.pathmapped.model.PathMap;
 import org.commonjava.storage.pathmapped.model.Reclaim;
 import org.commonjava.storage.pathmapped.spi.FileInfo;
 import org.commonjava.storage.pathmapped.spi.PathDB;
+import org.commonjava.storage.pathmapped.spi.PathDBAdmin;
 import org.commonjava.storage.pathmapped.spi.PhysicalStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -375,6 +377,14 @@ public class PathMappedFileManager implements Closeable
     public PathDB getPathDB()
     {
         return pathDB;
+    }
+
+    public Filesystem getFilesystem(String filesystem)
+    {
+        if (pathDB instanceof PathDBAdmin ) {
+            return ((PathDBAdmin)pathDB).getFilesystem(filesystem);
+        }
+        return null;
     }
 
     @Override

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/FilesystemTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/FilesystemTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.storage.pathmapped.model.Filesystem;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.io.OutputStream;
+
+import static org.junit.Assert.*;
+
+public class FilesystemTest
+        extends AbstractCassandraFMTest
+{
+    @Test
+    public void duplicateFileTest()
+            throws Exception
+    {
+        byte[] bytes = simpleContent.getBytes();
+        long fileSize = bytes.length;
+
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, path1 ))
+        {
+            IOUtils.write( bytes, os );
+        }
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, path2 ))
+        {
+            IOUtils.write( bytes, os );
+        }
+
+        // filesystem's size equals to just one file's size
+        Filesystem filesystem = fileManager.getFilesystem( TEST_FS );
+        assertThat( filesystem.getSize(), CoreMatchers.equalTo( fileSize ) );
+        assertThat( filesystem.getFileCount(), CoreMatchers.equalTo( 2L ) );
+
+        // after deleting one file, filesystem size not change, file count reduced by one
+        fileManager.delete( TEST_FS, path1 );
+        filesystem = fileManager.getFilesystem( TEST_FS );
+        assertThat( filesystem.getSize(), CoreMatchers.equalTo( fileSize ) );
+        assertThat( filesystem.getFileCount(), CoreMatchers.equalTo( 1L ) );
+
+        fileManager.delete( TEST_FS, path2 );
+        filesystem = fileManager.getFilesystem( TEST_FS );
+        assertThat( filesystem.getSize(), CoreMatchers.equalTo( 0L ) );
+        assertThat( filesystem.getFileCount(), CoreMatchers.equalTo( 0L ) );
+    }
+
+    @Test
+    public void runTest()
+            throws Exception
+    {
+        byte[] bytes = simpleContent.getBytes();
+        long fileSize = bytes.length;
+
+        final String anotherContent = "This is another test";
+        byte[] bytes2 = anotherContent.getBytes();
+        long fileSize2 = bytes2.length;
+
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, path1 ))
+        {
+            IOUtils.write( bytes, os );
+        }
+        try (OutputStream os = fileManager.openOutputStream( TEST_FS, path2 ))
+        {
+            IOUtils.write( bytes2, os );
+        }
+
+        // filesystem's size equals to file A + B
+        Filesystem filesystem = fileManager.getFilesystem( TEST_FS );
+        assertThat( filesystem.getSize(), CoreMatchers.equalTo( fileSize + fileSize2 ) );
+        assertThat( filesystem.getFileCount(), CoreMatchers.equalTo( 2L ) );
+
+        // after deleting file A, filesystem size equals to file B
+        fileManager.delete( TEST_FS, path1 );
+        filesystem = fileManager.getFilesystem( TEST_FS );
+        assertThat( filesystem.getSize(), CoreMatchers.equalTo( fileSize2 ) );
+        assertThat( filesystem.getFileCount(), CoreMatchers.equalTo( 1L ) );
+
+        fileManager.delete( TEST_FS, path2 );
+        filesystem = fileManager.getFilesystem( TEST_FS );
+        assertThat( filesystem.getSize(), CoreMatchers.equalTo( 0L ) );
+        assertThat( filesystem.getFileCount(), CoreMatchers.equalTo( 0L ) );
+    }
+}


### PR DESCRIPTION
There is an earlier chat about sonatype s3 size. I thought it was good to know the size for Indy 'filesystem'. 
I add a table to store the file count and total size. Not sure how useful for now. Maybe PNC can tell users the total disk they have consumed and clean something old. 
I am not sure how to set the initial size for old repos. Listing and counting a repo is heavy for big ones. So this feature is useful only for the new repos. 
Updating the size info is in async threads. I also move some code to async mode, like updating the reverse-map, mkdir, etc.
If you think this is good feature, I'll merge it.