### PR TITLE
Support multiple checksum for certain filesystems

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -17,18 +17,19 @@ package org.commonjava.storage.pathmapped.config;
 
 public interface PathMappedStorageConfig
 {
-
     int getGCIntervalInMinutes();
 
     int getGCGracePeriodInHours();
 
-    String getFileChecksumAlgorithm();
+    int getGCBatchSize();
+
+    String getChecksumAlgorithms();
 
     String getDeduplicatePattern();
 
-    Object getProperty( String key );
+    String getDeduplicateChecksumAlgorithm();
 
-    int getGCBatchSize();
+    Object getProperty( String key );
 
     String getCommonFileExtensions();
 

--- a/pathdb/pom.xml
+++ b/pathdb/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.commonjava.util</groupId>
             <artifactId>path-mapped-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
         <!--Test-->
         <dependency>

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -26,7 +26,7 @@ public class DefaultPathMappedStorageConfig
 
     private final int DEFAULT_GC_GRACE_PERIOD_IN_HOURS = 24;
 
-    private final String DEFAULT_FILE_CHECKSUM_ALGORITHM = "SHA-256";
+    private final String DEFAULT_CHECKSUM_ALGORITHM = "SHA-256";
 
     private int gcGracePeriodInHours = DEFAULT_GC_GRACE_PERIOD_IN_HOURS;
 
@@ -34,9 +34,11 @@ public class DefaultPathMappedStorageConfig
 
     private int gcBatchSize = DEFAULT_GC_BATCH_SIZE;
 
-    private String fileChecksumAlgorithm = DEFAULT_FILE_CHECKSUM_ALGORITHM;
+    private String checksumAlgorithms = DEFAULT_CHECKSUM_ALGORITHM;
 
     private String deduplicatePattern;
+
+    private String deduplicateChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM;
 
     private static final String DEFAULT_COMMON_FILE_EXTENSIONS = ".+\\.(jar|json|xml|pom|gz|tgz|md5|sha1|sha256)$";
 
@@ -76,14 +78,14 @@ public class DefaultPathMappedStorageConfig
     }
 
     @Override
-    public String getFileChecksumAlgorithm()
+    public String getChecksumAlgorithms()
     {
-        return fileChecksumAlgorithm;
+        return checksumAlgorithms;
     }
 
-    public void setFileChecksumAlgorithm( String fileChecksumAlgorithm )
+    public void setChecksumAlgorithms(String checksumAlgorithms)
     {
-        this.fileChecksumAlgorithm = fileChecksumAlgorithm;
+        this.checksumAlgorithms = checksumAlgorithms;
     }
 
     private Map<String, Object> properties;
@@ -138,5 +140,14 @@ public class DefaultPathMappedStorageConfig
 
     public void setPhysicalFileExistenceCheckEnabled(boolean physicalFileExistenceCheckEnabled) {
         this.physicalFileExistenceCheckEnabled = physicalFileExistenceCheckEnabled;
+    }
+
+    @Override
+    public String getDeduplicateChecksumAlgorithm() {
+        return deduplicateChecksumAlgorithm;
+    }
+
+    public void setDeduplicateChecksumAlgorithm(String deduplicateChecksumAlgorithm) {
+        this.deduplicateChecksumAlgorithm = deduplicateChecksumAlgorithm;
     }
 }

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/util/ChecksumCalculator.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/util/ChecksumCalculator.java
@@ -18,12 +18,16 @@ package org.commonjava.storage.pathmapped.util;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
 
 public class ChecksumCalculator
 {
     private final MessageDigest digester;
+
+    private String algorithm;
 
     private String digestHex;
 
@@ -41,6 +45,18 @@ public class ChecksumCalculator
         {
             this.digester = MessageDigest.getInstance( algorithm, this.provider );
         }
+        this.algorithm = algorithm;
+    }
+
+    public static List<ChecksumCalculator> asList( String algorithms ) throws NoSuchAlgorithmException
+    {
+        List<ChecksumCalculator> ret = new ArrayList<>();
+        String[] tokens = algorithms.split("," );
+        for (String s : tokens)
+        {
+            ret.add( new ChecksumCalculator( s.trim() ) );
+        }
+        return ret;
     }
 
     public final void update( final byte[] data )
@@ -66,4 +82,10 @@ public class ChecksumCalculator
         }
         return digestHex;
     }
+
+    public String getAlgorithm()
+    {
+        return algorithm;
+    }
+
 }


### PR DESCRIPTION
This is for [MMENG-3056](https://issues.redhat.com/browse/MMENG-3056). 

I tried to make this pr but found this dramatically increase the complexity of storage code. Mainly because the checksum can be a file OR a field in db entry. This cause big trouble when we want to use it, because we have to check both. Many methods are impacted, e.g, openInputStream, exist, etc. 

Because the checksums were to be stored in one filed, it has to go through json serialize/deserialize when write/read. This also introduce more complexity and performance concerns. 

I am afraid this could cause unnecessary issues, with no big gains. I want to drop this pr. wdyt?