### PR TITLE
Fix copy that causing physical file being reclaimed

### DIFF
--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -353,7 +353,7 @@ public class PathMappedFileManager implements Closeable
                 boolean result = physicalStore.delete( fileInfo );
                 if ( result )
                 {
-                    logger.debug( "Delete from physicalStore, fileInfo: {}", fileInfo );
+                    logger.info( "Delete from physicalStore, fileInfo: {}", fileInfo );
                     pathDB.removeFromReclaim( reclaim );
                 }
                 gcResults.put( fileInfo, result );


### PR DESCRIPTION
When copy a file from src to target, the insert method will use the existing physical file and remove the current file. However, in the case of copying, the current file is equal to existing file. This will cause the physical file being reclaimed. This fix add an 'if' to avoid it.

This pr also include some log changes, and use 'setConsistencyLevel(QUORUM)' to make the reverse map 'update-and-check' more reliable.