### PR TITLE
Use safe gc

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -35,4 +35,6 @@ public interface PathMappedStorageConfig
     default boolean isPhysicalFileExistenceCheckEnabled() {
         return false;
     }
+
+    int getGcMaxResultSize();
 }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -827,7 +827,6 @@ public class CassandraPathDB
         // timestamp data type is encoded as the number of milliseconds since epoch
         Date cur = new Date();
         long threshold = getReclaimThreshold( cur, config.getGCGracePeriodInHours() );
-        logger.debug( "listOrphanedFiles, cur: {}, threshold: {}, limit: {}", cur, new Date( threshold ), limit );
         ResultSet result;
         String baseQuery = "SELECT * FROM " + keyspace + ".reclaim WHERE partition = 0 AND deletion < ?";
         if ( limit > 0 )
@@ -838,8 +837,10 @@ public class CassandraPathDB
         {
             result = session.execute( baseQuery + ";", threshold );
         }
-        Result<DtxReclaim> ret = reclaimMapper.map( result );
-        return new ArrayList<>( ret.all() );
+        Result<DtxReclaim> dtxReclaims = reclaimMapper.map( result );
+        ArrayList<Reclaim> ret = new ArrayList<>( dtxReclaims.all() );
+        logger.info( "List orphaned files, cur: {}, threshold: {}, limit: {}, size: {}", cur, new Date( threshold ), limit, ret.size() );
+        return ret;
     }
 
     @Override

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -22,6 +22,8 @@ public class DefaultPathMappedStorageConfig
 {
     private static final int DEFAULT_GC_BATCH_SIZE = 0; // no limit
 
+    private static final int MAX_GC_RESULT_SIZE = 10000;
+
     private final int DEFAULT_GC_INTERVAL_IN_MINUTES = 60;
 
     private final int DEFAULT_GC_GRACE_PERIOD_IN_HOURS = 24;
@@ -33,6 +35,8 @@ public class DefaultPathMappedStorageConfig
     private int gcIntervalInMinutes = DEFAULT_GC_INTERVAL_IN_MINUTES;
 
     private int gcBatchSize = DEFAULT_GC_BATCH_SIZE;
+
+    private int gcMaxResultSize = MAX_GC_RESULT_SIZE;
 
     private String fileChecksumAlgorithm = DEFAULT_FILE_CHECKSUM_ALGORITHM;
 
@@ -138,5 +142,16 @@ public class DefaultPathMappedStorageConfig
 
     public void setPhysicalFileExistenceCheckEnabled(boolean physicalFileExistenceCheckEnabled) {
         this.physicalFileExistenceCheckEnabled = physicalFileExistenceCheckEnabled;
+    }
+
+    @Override
+    public int getGcMaxResultSize()
+    {
+        return gcMaxResultSize;
+    }
+
+    public void setGcMaxResultSize(int gcMaxResultSize)
+    {
+        this.gcMaxResultSize = gcMaxResultSize;
     }
 }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/GcTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/GcTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.commonjava.storage.pathmapped.model.Reclaim;
+import org.commonjava.storage.pathmapped.spi.PathDB;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class GcTest
+        extends AbstractCassandraFMTest
+{
+    @Test
+    public void gcTest() throws Exception
+    {
+        writeWithContent( TEST_FS, path1, "simpleContent1" );
+        writeWithContent( TEST_FS, path2, "simpleContent2" );
+
+        PathDB pathDB = fileManager.getPathDB();
+        List<Reclaim> orFiles = pathDB.listOrphanedFiles();
+        assertEquals(0, orFiles.size());
+
+        fileManager.delete(TEST_FS, path1);
+        orFiles = pathDB.listOrphanedFiles();
+        assertEquals(1, orFiles.size());
+
+        fileManager.gc();
+
+        orFiles = pathDB.listOrphanedFiles();
+        assertEquals(0, orFiles.size());
+
+        System.out.println("Test complete\n");
+    }
+
+}


### PR DESCRIPTION
To debug why prod gc broken, I add two parts: 
1. check for duplicate reclaim object. if gc get dup object, it indicates the listOrphanedFiles returns same objects for each loop. We need to break gc, or it will never end. 
2. add a config for max result. in case the results are too big. currently it is default 10,000 for each gc. 

I also add a unit test for gc, but do not find problem.