### PR TITLE
Extend file timeout for accessing

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/config/PathMappedStorageConfig.java
@@ -37,4 +37,9 @@ public interface PathMappedStorageConfig
     }
 
     int getGcMaxResultSize();
+
+    /**
+     * Extend file timeout in milliseconds for accessing (being accessed).
+     */
+    long getResetTimeoutForAccessing();
 }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -808,7 +808,7 @@ public class CassandraPathDB
     @Override
     public void expire(String fileSystem, String path, Date expiration)
     {
-        logger.debug( "Expire file, filesystem: {}, path: {}, expiration: {}", fileSystem, path, expiration );
+        logger.debug( "Set file expiration, filesystem: {}, path: {}, expiration: {}", fileSystem, path, expiration );
         String parentPath = PathMapUtils.getParentPath( path );
         String filename = PathMapUtils.getFilename( path );
         BoundStatement bound = preparedUpdateExpiration.bind();

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/config/DefaultPathMappedStorageConfig.java
@@ -16,6 +16,7 @@
 package org.commonjava.storage.pathmapped.config;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultPathMappedStorageConfig
                 implements PathMappedStorageConfig
@@ -23,6 +24,8 @@ public class DefaultPathMappedStorageConfig
     private static final int DEFAULT_GC_BATCH_SIZE = 0; // no limit
 
     private static final int MAX_GC_RESULT_SIZE = 100000;
+
+    private static final long DEFAULT_RESET_TIMEOUT_FOR_ACCESSING = TimeUnit.HOURS.toMillis( 12 );
 
     private final int DEFAULT_GC_INTERVAL_IN_MINUTES = 60;
 
@@ -37,6 +40,8 @@ public class DefaultPathMappedStorageConfig
     private int gcBatchSize = DEFAULT_GC_BATCH_SIZE;
 
     private int gcMaxResultSize = MAX_GC_RESULT_SIZE;
+
+    private long resetTimeoutForAccessing = DEFAULT_RESET_TIMEOUT_FOR_ACCESSING;
 
     private String fileChecksumAlgorithm = DEFAULT_FILE_CHECKSUM_ALGORITHM;
 
@@ -153,5 +158,16 @@ public class DefaultPathMappedStorageConfig
     public void setGcMaxResultSize(int gcMaxResultSize)
     {
         this.gcMaxResultSize = gcMaxResultSize;
+    }
+
+    @Override
+    public long getResetTimeoutForAccessing()
+    {
+        return resetTimeoutForAccessing;
+    }
+
+    public void setResetTimeoutForAccessing(long resetTimeoutForAccessing)
+    {
+        this.resetTimeoutForAccessing = resetTimeoutForAccessing;
     }
 }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/AbstractCassandraFMTest.java
@@ -26,11 +26,8 @@ import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
 import org.commonjava.storage.pathmapped.pathdb.datastax.CassandraPathDB;
 import org.commonjava.storage.pathmapped.pathdb.datastax.model.DtxPathMap;
 import org.commonjava.storage.pathmapped.pathdb.datastax.model.DtxReverseMap;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.hamcrest.CoreMatchers;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
@@ -38,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_HOST;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_KEYSPACE;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_PORT;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractCassandraFMTest
 {
@@ -234,6 +233,29 @@ public abstract class AbstractCassandraFMTest
         catch ( IOException e )
         {
             e.printStackTrace();
+        }
+    }
+
+    protected void checkRead( final String fileSys, final String path, final boolean exists, final String expected )
+    {
+        try (InputStream is = fileManager.openInputStream( fileSys, path ))
+        {
+            if ( exists )
+            {
+                Assert.assertThat( is, CoreMatchers.notNullValue() );
+                Assert.assertThat( IOUtils.toString( is ), CoreMatchers.equalTo( expected ) );
+            }
+            else
+            {
+                Assert.assertThat( is, CoreMatchers.nullValue() );
+            }
+        }
+        catch ( IOException e )
+        {
+            if ( exists || expected != null )
+            {
+                fail( "Open input stream failed, " + e.getMessage() );
+            }
         }
     }
 

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ChecksumDedupeTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ChecksumDedupeTest.java
@@ -15,20 +15,16 @@
  */
 package org.commonjava.storage.pathmapped;
 
-import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.fail;
 
 public class ChecksumDedupeTest
         extends AbstractCassandraFMTest
@@ -201,27 +197,4 @@ public class ChecksumDedupeTest
         Thread.sleep( GC_WAIT_MS );
     }
 
-    private void checkRead( final String fileSys, final String path, final boolean exists,
-                            final String expected )
-    {
-        try (InputStream is = fileManager.openInputStream( fileSys, path ))
-        {
-            if ( exists )
-            {
-                Assert.assertThat( is, CoreMatchers.notNullValue() );
-                Assert.assertThat( IOUtils.toString( is ), CoreMatchers.equalTo( expected ) );
-            }
-            else
-            {
-                Assert.assertThat( is, CoreMatchers.nullValue() );
-            }
-        }
-        catch ( IOException e )
-        {
-            if ( exists || expected != null )
-            {
-                fail( "An existed file path can not be opened to read successfully!" );
-            }
-        }
-    }
 }

--- a/storage/src/test/java/org/commonjava/storage/pathmapped/ResetTimeoutTest.java
+++ b/storage/src/test/java/org/commonjava/storage/pathmapped/ResetTimeoutTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped;
+
+import org.commonjava.storage.pathmapped.model.PathMap;
+import org.commonjava.storage.pathmapped.spi.PathDB;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.*;
+
+public class ResetTimeoutTest
+        extends AbstractCassandraFMTest
+{
+    /**
+     * This case tests reset file timeout for accessing.
+     */
+    @Test
+    public void run() throws Exception
+    {
+        final long timeoutSeconds = 1;
+        final String content = "This is a test";
+
+        // Prepare the test file which will expire in '1s'
+        writeWithContent( TEST_FS, path1, content, timeoutSeconds, TimeUnit.SECONDS );
+
+        PathDB pathDB = fileManager.getPathDB();
+
+        // Check the original expiration
+        PathMap pathMap = fileManager.getPathMap(TEST_FS, path1);
+        System.out.println(">>> (original) " + pathMap.getExpiration());
+
+        // File is NOT timeout at this moment
+        String storageFile = pathDB.getStorageFile(TEST_FS, path1);
+        //System.out.println(">>>" + storageFile);
+        assertNotNull(storageFile);
+
+        // Access the file, extend the expiration (default 12h)
+        checkRead(TEST_FS, path1, true, content);
+
+        // Sleep...
+        sleep(timeoutSeconds * 1000);
+
+        // Check file is NOT expired
+        pathMap = fileManager.getPathMap(TEST_FS, path1);
+        Date newTimeout = pathMap.getExpiration();
+        System.out.println(">>> (extended) " + newTimeout);
+        storageFile = pathDB.getStorageFile(TEST_FS, path1);
+        //System.out.println(">>>" + storageFile);
+        assertNotNull(storageFile);
+
+        // File accessed again, extend the expiration one more time (after sleep, the timeout is less than 12h from now)
+        checkRead(TEST_FS, path1, true, content);
+        pathMap = fileManager.getPathMap(TEST_FS, path1);
+        Date finalTimeout = pathMap.getExpiration();
+        System.out.println(">>> (final) " + finalTimeout);
+
+        // Future file accessing, expiration not change
+        checkRead(TEST_FS, path1, true, content);
+        pathMap = fileManager.getPathMap(TEST_FS, path1);
+        assertEquals( finalTimeout, pathMap.getExpiration() );
+    }
+
+}


### PR DESCRIPTION
This is for [MMENG-3816](https://issues.redhat.com/browse/MMENG-3816) Reset the timestamp for accessing the regular artifacts.

If 'resetTimeoutForAccessing' configured (default 12h), reset expiration when it is close to due date to prevent commonly used files being expired too soon.