### PR TITLE
Use hours-in-day as reclaim table partition

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxReclaim.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxReclaim.java
@@ -24,11 +24,13 @@ import org.commonjava.storage.pathmapped.model.Reclaim;
 import java.util.Date;
 import java.util.Objects;
 
+import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.getHoursInDay;
+
 @Table( name = "reclaim", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
 public class DtxReclaim implements Reclaim
 {
     @PartitionKey
-    private int partition; // use fixed partition 0 in order to run SELECT fast
+    private int partition; // partition by hours in day (0~23)
 
     @ClusteringColumn(0)
     private Date deletion;
@@ -48,6 +50,7 @@ public class DtxReclaim implements Reclaim
 
     public DtxReclaim( String fileId, Date deletion, String storage, String checksum )
     {
+        this.partition = getHoursInDay( deletion );
         this.fileId = fileId;
         this.deletion = deletion;
         this.storage = storage;
@@ -61,6 +64,7 @@ public class DtxReclaim implements Reclaim
 
     public void setPartition( int partition )
     {
+        this.partition = partition;
     }
 
     @Override

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -15,6 +15,9 @@
  */
 package org.commonjava.storage.pathmapped.pathdb.datastax.util;
 
+import java.util.Calendar;
+import java.util.Date;
+
 public class CassandraPathDBUtils
 {
     public static final String PROP_CASSANDRA_HOST = "cassandra_host";
@@ -97,5 +100,13 @@ public class CassandraPathDBUtils
                         + "storage varchar,"
                         + "PRIMARY KEY (checksum)"
                         + ");";
+    }
+
+    // Since Date.getHours is deprecated, we use this to replace it.
+    public static int getHoursInDay( Date date )
+    {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime( date );
+        return calendar.get( Calendar.HOUR_OF_DAY );
     }
 }


### PR DESCRIPTION
This is for [MMENG-3846](https://issues.redhat.com/browse/MMENG-3846). 
Current partition key is always 0 which may cause selection problem during GC. The hours-in-day as reclaim table partition split all records into 24 partitions which should help the querying. Functionally, there is no change. 