### PR TITLE
Support force delete for purging a whole file system

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -50,7 +50,15 @@ public interface PathDB
 
     boolean isFile( String fileSystem, String path );
 
+    /**
+     * Safe delete. Non-empty directory is not allowed to delete to protect the dir/file relationship in db.
+     */
     boolean delete( String fileSystem, String path );
+
+    /**
+     * Force delete. Used when listing and purging a whole file system.
+     */
+    boolean delete( String fileSystem, String path, boolean force );
 
     String getStorageFile( String fileSystem, String path );
 

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -607,6 +607,12 @@ public class CassandraPathDB
     @Override
     public boolean delete( String fileSystem, String path )
     {
+        return delete( fileSystem, path, false );
+    }
+
+    @Override
+    public boolean delete( String fileSystem, String path, boolean force )
+    {
         PathMap pathMap = getPathMap( fileSystem, path );
         if ( pathMap == null )
         {
@@ -617,10 +623,10 @@ public class CassandraPathDB
         String fileId = pathMap.getFileId();
         if ( fileId == null )
         {
-            // can only remove empty dir
-            if ( isEmptyDirectory( fileSystem, path ) )
+            // force or empty dir
+            if ( force || isEmptyDirectory( fileSystem, path ) )
             {
-                logger.info( "Delete empty dir, {}", pathMap );
+                logger.info( "Delete dir (force: {}), {}", force, pathMap );
                 pathMapMapper.delete( pathMap.getFileSystem(), pathMap.getParentPath(), pathMap.getFilename() );
                 return true;
             }

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
@@ -239,6 +239,12 @@ public class JPAPathDB
         return true;
     }
 
+    @Override
+    public boolean delete(String fileSystem, String path, boolean force)
+    {
+        return delete( fileSystem, path );
+    }
+
     private void removeFromReverseMap( String fileSystem, String path, PathMap pathMap )
     {
         String fileId = pathMap.getFileId();

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -181,7 +181,12 @@ public class PathMappedFileManager implements Closeable
 
     public boolean delete( String fileSystem, String path )
     {
-        return pathDB.delete( fileSystem, path );
+        return pathDB.delete( fileSystem, path, false );
+    }
+
+    public boolean delete( String fileSystem, String path, boolean force )
+    {
+        return pathDB.delete( fileSystem, path, force );
     }
 
     public String[] list( String fileSystem, String path )

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
@@ -112,6 +112,12 @@ public class MeasuredPathDB
     }
 
     @Override
+    public boolean delete(String fileSystem, String path, boolean force)
+    {
+        return measure( () -> decorated.delete( fileSystem, path, force ), "delete" );
+    }
+
+    @Override
     public Set<String> getFileSystemContaining( Collection<String> candidates, String path )
     {
         return measure( () -> decorated.getFileSystemContaining( candidates, path ), "getFileSystemContaining" );


### PR DESCRIPTION
Deletion of non-empty directory is not allowed in current code to protect the dir/file structure in db. But in case of listing & purging a whole file system, we need to force deletion for all dirs/files. This pr add the support for that.