### PR TITLE
Update Cassandra reconnect policy and default delay value

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -28,6 +28,8 @@ public class CassandraPathDBUtils
 
     public static final String PROP_CASSANDRA_PASS = "cassandra_pass";
 
+    public static final String PROP_CASSANDRA_RECONNECT_DELAY = "cassandra_reconnect_delay";
+
     public static final String PROP_CASSANDRA_KEYSPACE = "cassandra_keyspace";
 
     public static final String PROP_CASSANDRA_REPLICATION_FACTOR = "cassandra_replication_factor";


### PR DESCRIPTION
Use ConstantReconnectionPolicy instead of exponential policy, see https://issues.redhat.com/browse/MMENG-4231.