### PR TITLE
Add proxy cache on CassandraPathDB

### DIFF
--- a/common/src/main/java/org/commonjava/storage/pathmapped/model/ProxySite.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/model/ProxySite.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.model;
+
+public interface ProxySite
+{
+    String getSite();
+}

--- a/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
+++ b/common/src/main/java/org/commonjava/storage/pathmapped/spi/PathDB.java
@@ -104,4 +104,16 @@ public interface PathDB
      * @param fileType file, dir, or all
      */
     void traverse( String fileSystem, String path, Consumer<PathMap> consumer, int limit, FileType fileType );
+
+    Set<String> getProxySitesCache();
+
+    boolean isProxySite( String site );
+
+    List<String> getProxySiteList();
+
+    void saveProxySite( String site );
+
+    void deleteProxySite( String site );
+
+    void deleteAllProxySite();
 }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxProxySite.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/model/DtxProxySite.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.pathdb.datastax.model;
+
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.commonjava.storage.pathmapped.model.ProxySite;
+
+import java.util.Objects;
+
+@Table( name = "proxysites", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxProxySite
+        implements ProxySite
+{
+    @PartitionKey
+    private String site;
+
+    public DtxProxySite()
+    {
+    }
+
+    public DtxProxySite( String site )
+    {
+        this.site = site;
+    }
+
+    @Override
+    public String getSite()
+    {
+        return site;
+    }
+
+    public void setSite( String site )
+    {
+        this.site = site;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        DtxProxySite that = (DtxProxySite) o;
+        return site.equals( that.site );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( site );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DtxProxySite{" + "site='" + site + '}';
+    }
+}

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -96,12 +96,14 @@ public class CassandraPathDBUtils
 
     public static String getSchemaCreateTableFileChecksum( String keyspace )
     {
-        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".filechecksum ("
-                        + "checksum varchar,"
-                        + "fileid varchar,"
-                        + "storage varchar,"
-                        + "PRIMARY KEY (checksum)"
-                        + ");";
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".filechecksum (" + "checksum varchar," + "fileid varchar,"
+                + "storage varchar," + "PRIMARY KEY (checksum)" + ");";
+    }
+
+    public static String getSchemaCreateTableProxySites( String keyspace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".proxysites (" + "site varchar," + "PRIMARY KEY (site)"
+                + ");";
     }
 
     // Since Date.getHours is deprecated, we use this to replace it.

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
@@ -15,24 +15,24 @@
  */
 package org.commonjava.storage.pathmapped.pathdb.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.Query;
 import org.commonjava.storage.pathmapped.model.FileChecksum;
+import org.commonjava.storage.pathmapped.model.PathMap;
+import org.commonjava.storage.pathmapped.model.Reclaim;
+import org.commonjava.storage.pathmapped.model.ReverseMap;
 import org.commonjava.storage.pathmapped.pathdb.jpa.model.JpaPathKey;
 import org.commonjava.storage.pathmapped.pathdb.jpa.model.JpaPathMap;
 import org.commonjava.storage.pathmapped.pathdb.jpa.model.JpaReclaim;
 import org.commonjava.storage.pathmapped.pathdb.jpa.model.JpaReverseKey;
 import org.commonjava.storage.pathmapped.pathdb.jpa.model.JpaReverseMap;
-import org.commonjava.storage.pathmapped.model.PathMap;
-import org.commonjava.storage.pathmapped.model.Reclaim;
-import org.commonjava.storage.pathmapped.model.ReverseMap;
 import org.commonjava.storage.pathmapped.spi.PathDB;
 import org.commonjava.storage.pathmapped.util.PathMapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
-import jakarta.persistence.Query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -437,4 +437,36 @@ public class JPAPathDB
         return new JpaPathKey( fileSystem, parentPath, filename );
     }
 
+    @Override
+    public Set<String> getProxySitesCache()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean isProxySite( String site )
+    {
+        return false;
+    }
+
+    @Override
+    public List<String> getProxySiteList()
+    {
+        return null;
+    }
+
+    @Override
+    public void saveProxySite( String site )
+    {
+    }
+
+    @Override
+    public void deleteProxySite( String site )
+    {
+    }
+
+    @Override
+    public void deleteAllProxySite()
+    {
+    }
 }

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaProxySite.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaProxySite.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.storage.pathmapped.pathdb.jpa.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.commonjava.storage.pathmapped.model.ProxySite;
+
+import java.util.Objects;
+
+@Entity
+@Table( name = "proxysites" )
+public class JpaProxySite
+        implements ProxySite
+{
+    @Id
+    private String site;
+
+    public JpaProxySite()
+    {
+    }
+
+    public JpaProxySite( String site )
+    {
+        this.site = site;
+    }
+
+    @Override
+    public String getSite()
+    {
+        return site;
+    }
+
+    public void setSite( String site )
+    {
+        this.site = site;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        JpaProxySite that = (JpaProxySite) o;
+        return site.equals( that.site );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( site );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "JpaProxySite{" + "site='" + site + '}';
+    }
+}

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -32,7 +32,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -476,11 +481,42 @@ public class PathMappedFileManager implements Closeable
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
+            throws IOException
     {
         if ( pathDB instanceof Closeable )
         {
             ( (Closeable) pathDB ).close();
         }
+    }
+
+    public Set<String> getProxySitesCache()
+    {
+        return pathDB.getProxySitesCache();
+    }
+
+    public boolean isProxySite( String site )
+    {
+        return pathDB.isProxySite( site );
+    }
+
+    public List<String> getProxySiteList()
+    {
+        return pathDB.getProxySiteList();
+    }
+
+    public void saveProxySite( String site )
+    {
+        pathDB.saveProxySite( site );
+    }
+
+    public void deleteProxySite( String site )
+    {
+        pathDB.deleteProxySite( site );
+    }
+
+    public void deleteAllProxySite()
+    {
+        pathDB.deleteAllProxySite();
     }
 }

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/metrics/MeasuredPathDB.java
@@ -221,4 +221,39 @@ public class MeasuredPathDB
         return true;
     }
 
+    @Override
+    public Set<String> getProxySitesCache()
+    {
+        return measure( () -> decorated.getProxySitesCache(), "getProxySitesCache" );
+    }
+
+    @Override
+    public boolean isProxySite( String site )
+    {
+        return measure( () -> decorated.isProxySite( site ), "isProxySite" );
+    }
+
+    @Override
+    public List<String> getProxySiteList()
+    {
+        return measure( () -> decorated.getProxySiteList(), "getProxySiteList" );
+    }
+
+    @Override
+    public void saveProxySite( String site )
+    {
+        measure( () -> decorated.saveProxySite( site ), "saveProxySite" );
+    }
+
+    @Override
+    public void deleteProxySite( String site )
+    {
+        measure( () -> decorated.deleteProxySite( site ), "deleteProxySite" );
+    }
+
+    @Override
+    public void deleteAllProxySite()
+    {
+        measure( () -> decorated.deleteAllProxySite(), "deleteAllProxySite" );
+    }
 }


### PR DESCRIPTION
Note: getProxySitesCache is used for cache layer for db query, to avoid frequent query for each download, it could be clean for Proxy Site delete request, could check the detail on galley commit.