### PR TITLE
Revert "Update to jakarta namespace for jpa module (#115)"

### DIFF
--- a/pathdb/jpa/pom.xml
+++ b/pathdb/jpa/pom.xml
@@ -29,9 +29,9 @@
     <dependencies>
         <!-- JPA support-->
         <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
         </dependency>
 
         <!--Test-->

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/JPAPathDB.java
@@ -29,10 +29,10 @@ import org.commonjava.storage.pathmapped.util.PathMapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaFileChecksum.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaFileChecksum.java
@@ -17,10 +17,10 @@ package org.commonjava.storage.pathmapped.pathdb.jpa.model;
 
 import org.commonjava.storage.pathmapped.model.FileChecksum;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.util.Objects;
 
 @Entity

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaPathKey.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaPathKey.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.storage.pathmapped.pathdb.jpa.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaPathMap.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaPathMap.java
@@ -17,10 +17,10 @@ package org.commonjava.storage.pathmapped.pathdb.jpa.model;
 
 import org.commonjava.storage.pathmapped.model.PathMap;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.util.Date;
 import java.util.Objects;
 

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaReclaim.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaReclaim.java
@@ -17,10 +17,10 @@ package org.commonjava.storage.pathmapped.pathdb.jpa.model;
 
 import org.commonjava.storage.pathmapped.model.Reclaim;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.util.Date;
 import java.util.Objects;
 

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaReverseKey.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaReverseKey.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.storage.pathmapped.pathdb.jpa.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaReverseMap.java
+++ b/pathdb/jpa/src/main/java/org/commonjava/storage/pathmapped/pathdb/jpa/model/JpaReverseMap.java
@@ -17,10 +17,10 @@ package org.commonjava.storage.pathmapped.pathdb.jpa.model;
 
 import org.commonjava.storage.pathmapped.model.ReverseMap;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <properties>
         <projectOwner>Red Hat, Inc.</projectOwner>
         <projectEmail>nos-devel@redhat.com</projectEmail>
-        <javaVersion>11</javaVersion>
+        <javaVersion>1.8</javaVersion>
         <test-forkCount>1</test-forkCount>
         <cassandraVersion>3.12.1</cassandraVersion>
         <cassandraUnitVersion>3.11.2.0</cassandraUnitVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <properties>
         <projectOwner>Red Hat, Inc.</projectOwner>
         <projectEmail>nos-devel@redhat.com</projectEmail>
-        <javaVersion>1.8</javaVersion>
+        <javaVersion>11</javaVersion>
         <test-forkCount>1</test-forkCount>
         <cassandraVersion>3.12.1</cassandraVersion>
         <cassandraUnitVersion>3.11.2.0</cassandraUnitVersion>


### PR DESCRIPTION
This reverts commit 26ea824.

This moves back to using javax persistence. Using this galley is once more able to test against this. The `pathdb/jpa` module is referring to hibernate version 5 (although it mentions test scope and there are no tests). Overall path-mapped-storage refers to hibernate 5 (not 6 where they changed to jakarta https://docs.hibernate.org/orm/6.0/migration-guide/#_jakarta_persistence )