### PR TITLE
fix: add Cassandra compaction strategies and improve GC reliability

### DIFF
--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/CassandraPathDB.java
@@ -891,22 +891,39 @@ public class CassandraPathDB
     @Override
     public List<Reclaim> listOrphanedFiles( int limit )
     {
-        // timestamp data type is encoded as the number of milliseconds since epoch
         Date cur = new Date();
-        int partition = getHoursInDay( cur );
         long threshold = getReclaimThreshold( cur, config.getGCGracePeriodInHours() );
-        ResultSet result;
+        ArrayList<Reclaim> ret = new ArrayList<>();
         String baseQuery = "SELECT * FROM " + keyspace + ".reclaim WHERE partition = ? AND deletion < ?";
-        if ( limit > 0 )
+        PreparedStatement stmt = session.prepare( baseQuery + ( limit > 0 ? " limit ?" : "" ) + ";" );
+
+        for ( int partition = 0; partition < 24; partition++ )
         {
-            result = session.execute( baseQuery + " limit ?;", partition, threshold, limit );
+            try
+            {
+                BoundStatement bound;
+                if ( limit > 0 )
+                {
+                    int remaining = limit - ret.size();
+                    if ( remaining <= 0 )
+                    {
+                        break;
+                    }
+                    bound = stmt.bind( partition, threshold, remaining );
+                }
+                else
+                {
+                    bound = stmt.bind( partition, threshold );
+                }
+                ResultSet result = executeSession( bound );
+                Result<DtxReclaim> dtxReclaims = reclaimMapper.map( result );
+                ret.addAll( dtxReclaims.all() );
+            }
+            catch ( Exception e )
+            {
+                logger.warn( "Failed to query reclaim partition {}: {}", partition, e.getMessage() );
+            }
         }
-        else
-        {
-            result = session.execute( baseQuery + ";", partition, threshold );
-        }
-        Result<DtxReclaim> dtxReclaims = reclaimMapper.map( result );
-        ArrayList<Reclaim> ret = new ArrayList<>( dtxReclaims.all() );
         logger.info( "List orphaned files, cur: {}, threshold: {}, limit: {}, size: {}", cur, new Date( threshold ), limit, ret.size() );
         return ret;
     }

--- a/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
+++ b/pathdb/datastax/src/main/java/org/commonjava/storage/pathmapped/pathdb/datastax/util/CassandraPathDBUtils.java
@@ -70,7 +70,7 @@ public class CassandraPathDBUtils
                         + "filestorage varchar,"
                         + "checksum varchar,"
                         + "PRIMARY KEY ((filesystem, parentpath), filename)"
-                        + ");";
+                        + ") WITH compaction = {'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb': '160'};";
     }
 
     public static String getSchemaCreateTableReversemap( String keyspace )
@@ -79,7 +79,7 @@ public class CassandraPathDBUtils
                         + "fileid varchar,"
                         + "paths set<text>,"
                         + "PRIMARY KEY (fileid)"
-                        + ");";
+                        + ") WITH compaction = {'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb': '160'};";
     }
 
     public static String getSchemaCreateTableReclaim( String keyspace )
@@ -91,7 +91,8 @@ public class CassandraPathDBUtils
                         + "checksum varchar,"
                         + "storage varchar,"
                         + "PRIMARY KEY (partition, deletion, fileid)"
-                        + ");";
+                        + ") WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'HOURS', 'compaction_window_size': '4'}"
+                        + " AND gc_grace_seconds = 14400;";
     }
 
     public static String getSchemaCreateTableFileChecksum( String keyspace )
@@ -101,7 +102,7 @@ public class CassandraPathDBUtils
                         + "fileid varchar,"
                         + "storage varchar,"
                         + "PRIMARY KEY (checksum)"
-                        + ");";
+                        + ") WITH compaction = {'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb': '160'};";
     }
 
     // Since Date.getHours is deprecated, we use this to replace it.

--- a/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
+++ b/storage/src/main/java/org/commonjava/storage/pathmapped/core/PathMappedFileManager.java
@@ -59,6 +59,8 @@ public class PathMappedFileManager implements Closeable
 
     private String deduplicatePattern;
 
+    private int consecutiveGcFailures = 0;
+
     public PathMappedFileManager( PathMappedStorageConfig config, PathDB pathDB, PhysicalStore physicalStore )
     {
         this.pathDB = pathDB;
@@ -388,11 +390,23 @@ public class PathMappedFileManager implements Closeable
     {
         try
         {
-            return executeGC();
+            Map<FileInfo, Boolean> result = executeGC();
+            consecutiveGcFailures = 0;
+            return result;
         }
         catch (Exception e)
         {
-            logger.warn("Storage gc hit a problem but will continue to execute next time", e);
+            consecutiveGcFailures++;
+            if ( consecutiveGcFailures >= 3 )
+            {
+                logger.error( "Storage gc failed {} consecutive times. Last error: {} - {}. Manual intervention may be required.",
+                              consecutiveGcFailures, e.getClass().getSimpleName(), e.getMessage(), e );
+            }
+            else
+            {
+                logger.warn( "Storage gc hit a problem (failure {} of 3 before escalation): {} - {}",
+                             consecutiveGcFailures, e.getClass().getSimpleName(), e.getMessage(), e );
+            }
         }
         return emptyMap();
     }


### PR DESCRIPTION
## Summary

- Add compaction strategies to all CREATE TABLE statements (LCS for pathmap/reversemap/filechecksum, TWCS for reclaim)
- Fix `listOrphanedFiles()` to query all 24 hourly partitions instead of only the current hour
- Fix `listOrphanedFiles()` to use `executeSession()` wrapper for Cassandra reconnection handling
- Improve `gc()` error handling with consecutive failure counting (escalates WARN → ERROR after 3 failures)

## Context

Production incident on 2026-06-17 in `indy--runtime-int`:
- **187:1 tombstone-to-live-row ratio** on `indystorage.reclaim`
- **41-61 second GC pauses** on Cassandra nodes
- **Build promotion 504 timeouts** blocking multiple product releases
- **Stale maven-metadata.xml** and npm proxy socket timeouts

### Root causes in this codebase:

1. No compaction strategy on any CREATE TABLE — defaults to STCS (worst for deletion-heavy workloads)
2. \`listOrphanedFiles()\` only queries current hour partition — 23 of 24 partitions never processed
3. \`listOrphanedFiles()\` bypasses reconnection handling (uses raw session.execute)
4. \`gc()\` swallows all exceptions silently with no failure tracking

### Operational workarounds applied on prod (still running):
- ALTER TABLE compaction strategies
- Manual nodetool compact
- Cassandra node restarts

This PR ensures new deployments get correct configuration from the start.

## Backward Compatibility

- CREATE TABLE IF NOT EXISTS won't alter existing tables
- Existing deployments need ALTER TABLE to apply new strategies
- No data migration or API changes

Jira: SPRE-5528

🤖 Generated with [Claude Code](https://claude.com/claude-code)